### PR TITLE
Add uninstaller, improve install.sh error handling, and add Troublesh…

### DIFF
--- a/README.md
+++ b/README.md
@@ -207,6 +207,29 @@ doza-assist/
 
 ---
 
+## Troubleshooting
+
+**Install failing?**
+Run `bash install.sh --clean` to wipe the setup and start completely fresh.
+
+**Want to completely remove Doza Assist?**
+Run `bash uninstall.sh` — it will walk you through what gets removed and ask before doing anything.
+
+**Getting a Python error or "command not found"?**
+Make sure Xcode Command Line Tools are installed:
+```bash
+xcode-select --install
+```
+Wait for the installer to finish, then run `bash install.sh --clean`.
+
+**macOS blocking the app?**
+Go to **System Settings > Privacy & Security**, scroll down, and click **Open Anyway** next to the Doza Assist message. This only happens once.
+
+**Want to report a bug?**
+The installer saves a full log to `install_log.txt` in the project folder. Attach it when reporting issues — it shows exactly where things went wrong.
+
+---
+
 ## Privacy
 
 - All transcription runs locally on your machine

--- a/install.sh
+++ b/install.sh
@@ -1,91 +1,288 @@
 #!/bin/bash
 # ── Doza Assist Installer ──
-# Run this once on your Mac Studio
-
-set -e
-
-echo ""
-echo "  ╔═══════════════════════════════════╗"
-echo "  ║       Doza Assist Setup       ║"
-echo "  ╚═══════════════════════════════════╝"
-echo ""
+# Run this once from the project root.
+# Usage:  bash install.sh          — normal install
+#         bash install.sh --clean  — wipe everything and start fresh
 
 cd "$(dirname "$0")"
 
-# Check Python
-if ! command -v python3 &> /dev/null; then
-    echo "❌ Python 3 not found. Install from python.org"
+# ── Colors ──
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+BOLD='\033[1m'
+RESET='\033[0m'
+
+LOG_FILE="$(pwd)/install_log.txt"
+
+# ── Logging: write to file and terminal ──
+log() {
+    local msg="$1"
+    echo "$msg" | tee -a "$LOG_FILE"
+}
+
+log_raw() {
+    # No tee — used for color output that we also want stripped in the log
+    local msg="$1"
+    local plain
+    plain=$(echo -e "$msg" | sed 's/\x1b\[[0-9;]*m//g')
+    echo -e "$msg"
+    echo "$plain" >> "$LOG_FILE"
+}
+
+fail() {
+    local msg="$1"
+    local hint="$2"
+    log_raw ""
+    log_raw "${RED}${BOLD}ERROR:${RESET} $msg"
+    if [ -n "$hint" ]; then
+        log_raw "${YELLOW}What to do:${RESET} $hint"
+    fi
+    log_raw ""
+    log_raw "Full install log saved to: $LOG_FILE"
+    log_raw "Share this file when reporting issues."
+    echo "" >> "$LOG_FILE"
     exit 1
+}
+
+# ── Ensure Homebrew on PATH ──
+ensure_homebrew_on_path() {
+    if [ -d "/opt/homebrew/bin" ]; then
+        export PATH="/opt/homebrew/bin:$PATH"
+    elif [ -d "/usr/local/bin" ]; then
+        export PATH="/usr/local/bin:$PATH"
+    fi
+}
+
+ensure_homebrew_on_path
+
+# ── Header ──
+echo "" | tee "$LOG_FILE"   # reset log on each run
+log_raw "  ╔═══════════════════════════════════╗"
+log_raw "  ║       Doza Assist Setup           ║"
+log_raw "  ╚═══════════════════════════════════╝"
+log_raw ""
+log "  Install started: $(date)"
+log_raw ""
+
+# ── --clean flag: wipe and reinstall ──
+if [[ "$1" == "--clean" ]]; then
+    log_raw "${YELLOW}--clean flag detected. Running uninstaller before reinstalling...${RESET}"
+    log_raw ""
+    if [ -f "./uninstall.sh" ]; then
+        bash ./uninstall.sh
+        echo ""
+        log_raw "${GREEN}Clean complete. Starting fresh install...${RESET}"
+        log_raw ""
+    else
+        log_raw "${YELLOW}uninstall.sh not found — continuing with fresh install anyway.${RESET}"
+        # Manual cleanup of venv at minimum
+        rm -rf venv
+    fi
 fi
 
-echo "✓ Python found: $(python3 --version)"
+# ── Step 0: Xcode Command Line Tools ──
+log_raw "${BOLD}Checking for Xcode Command Line Tools...${RESET}"
 
-# Create virtual environment
+if ! xcode-select -p &>/dev/null; then
+    log_raw ""
+    log_raw "${YELLOW}macOS needs to install Command Line Tools first.${RESET}"
+    log_raw ""
+    log_raw "A dialog box should appear on your screen."
+    log_raw "Click ${BOLD}Install${RESET}, wait for it to finish, then press Enter here to continue."
+    log_raw ""
+
+    xcode-select --install 2>/dev/null || true
+
+    read -p "Press Enter once the Command Line Tools install is complete... " _
+
+    if ! xcode-select -p &>/dev/null; then
+        fail \
+            "Xcode Command Line Tools are still not installed." \
+            "Run 'xcode-select --install' in Terminal, wait for the installer to finish, then run 'bash install.sh' again."
+    fi
+fi
+
+log_raw "${GREEN}✓ Xcode Command Line Tools found: $(xcode-select -p)${RESET}"
+
+# ── Step 1: Python 3.11+ ──
+log_raw ""
+log_raw "${BOLD}Checking for Python 3.11+...${RESET}"
+
+find_python() {
+    for candidate in python3.13 python3.12 python3.11 python3; do
+        local py
+        py=$(command -v "$candidate" 2>/dev/null || true)
+        if [ -n "$py" ]; then
+            local ver
+            ver=$("$py" -c "import sys; print(f'{sys.version_info.major}.{sys.version_info.minor}')" 2>/dev/null || true)
+            if [ -n "$ver" ]; then
+                local major minor
+                major=$(echo "$ver" | cut -d. -f1)
+                minor=$(echo "$ver" | cut -d. -f2)
+                if [ "$major" -ge 3 ] && [ "$minor" -ge 11 ]; then
+                    echo "$py"
+                    return 0
+                fi
+            fi
+        fi
+    done
+    return 1
+}
+
+PYTHON=$(find_python 2>/dev/null || true)
+
+if [ -z "$PYTHON" ]; then
+    log_raw "${YELLOW}Python 3.11+ not found. Installing via Homebrew...${RESET}"
+
+    if ! command -v brew &>/dev/null; then
+        fail \
+            "Homebrew is not installed and Python 3.11+ was not found." \
+            "Install Homebrew first: /bin/bash -c \"\$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)\" — then run 'bash install.sh' again."
+    fi
+
+    brew install python@3.12 >> "$LOG_FILE" 2>&1 || \
+        fail \
+            "Python installation via Homebrew failed." \
+            "This usually means Xcode Command Line Tools aren't fully installed. Try running 'xcode-select --install', then 'bash install.sh --clean'."
+
+    ensure_homebrew_on_path
+    PYTHON=$(find_python 2>/dev/null || true)
+
+    if [ -z "$PYTHON" ]; then
+        fail \
+            "Python was installed but couldn't be found on PATH." \
+            "Close this Terminal window, open a new one, and run 'bash install.sh' again."
+    fi
+fi
+
+log_raw "${GREEN}✓ Python found: $PYTHON ($($PYTHON --version 2>&1))${RESET}"
+
+# ── Step 2: Virtual Environment ──
+log_raw ""
+log_raw "${BOLD}Setting up Python virtual environment...${RESET}"
+
 if [ ! -d "venv" ]; then
-    echo "Creating virtual environment..."
-    python3 -m venv venv
+    $PYTHON -m venv venv >> "$LOG_FILE" 2>&1 || \
+        fail \
+            "Failed to create the Python virtual environment." \
+            "Try running 'bash install.sh --clean' to start fresh. If it still fails, make sure Python is working: run '$PYTHON --version'."
 fi
 
-source venv/bin/activate
+# shellcheck source=/dev/null
+source venv/bin/activate || \
+    fail \
+        "Failed to activate the virtual environment." \
+        "Try deleting the venv folder and running 'bash install.sh' again."
 
-# Install core dependencies
-echo ""
-echo "Installing core dependencies..."
-pip install --upgrade pip -q
-pip install flask werkzeug requests -q
+log_raw "${GREEN}✓ Virtual environment ready${RESET}"
 
-# Install ffmpeg check
-if ! command -v ffmpeg &> /dev/null; then
-    echo ""
-    echo "⚠️  ffmpeg not found. Install with: brew install ffmpeg"
-    echo "   (Required for video file audio extraction)"
+# ── Step 3: Core pip packages ──
+log_raw ""
+log_raw "${BOLD}Installing core dependencies...${RESET}"
+
+pip install --upgrade pip >> "$LOG_FILE" 2>&1 || \
+    fail \
+        "Failed to upgrade pip." \
+        "Try running 'bash install.sh --clean' to start fresh."
+
+pip install flask werkzeug requests >> "$LOG_FILE" 2>&1 || \
+    fail \
+        "Failed to install Flask and core packages." \
+        "Check your internet connection and try again. If the problem persists, run 'bash install.sh --clean'."
+
+log_raw "${GREEN}✓ Core packages installed${RESET}"
+
+# ── Step 4: ffmpeg ──
+log_raw ""
+log_raw "${BOLD}Checking for ffmpeg...${RESET}"
+
+if ! command -v ffmpeg &>/dev/null; then
+    log_raw "${YELLOW}ffmpeg not found.${RESET} Trying to install via Homebrew..."
+
+    if command -v brew &>/dev/null; then
+        brew install ffmpeg >> "$LOG_FILE" 2>&1 && \
+            log_raw "${GREEN}✓ ffmpeg installed${RESET}" || \
+            log_raw "${YELLOW}⚠  ffmpeg install failed. You can install it later with: brew install ffmpeg${RESET}"
+    else
+        log_raw "${YELLOW}⚠  Homebrew not found. Install ffmpeg manually: brew install ffmpeg${RESET}"
+        log_raw "   ffmpeg is required for video file audio extraction."
+    fi
+else
+    log_raw "${GREEN}✓ ffmpeg found: $(command -v ffmpeg)${RESET}"
 fi
 
-# Install transcription engine
+# ── Step 5: Transcription Engine ──
+log_raw ""
+log_raw "${BOLD}Choose your transcription engine:${RESET}"
 echo ""
-echo "Choose your transcription engine:"
-echo "  1) WhisperX (RECOMMENDED - transcription + speaker diarization)"
-echo "  2) Lightning Whisper MLX (fastest, no diarization)"
-echo "  3) Standard Whisper (basic, word timestamps)"
-echo "  4) Skip (install later)"
+echo "  1) Parakeet TDT via MLX  (RECOMMENDED — fast, Apple Silicon native)"
+echo "  2) WhisperX              (transcription + speaker diarization)"
+echo "  3) Lightning Whisper MLX (fastest, no speaker labels)"
+echo "  4) Standard Whisper      (basic, most compatible)"
+echo "  5) Skip                  (install later)"
 echo ""
 read -p "Enter choice [1]: " engine_choice
 engine_choice=${engine_choice:-1}
 
 case $engine_choice in
     1)
-        echo "Installing WhisperX..."
-        pip install whisperx -q
-        echo ""
-        echo "⚠️  For speaker diarization, you need a HuggingFace token:"
-        echo "   1. Create account at huggingface.co"
-        echo "   2. Accept terms at: https://huggingface.co/pyannote/speaker-diarization-3.1"
-        echo "   3. Get token at: https://huggingface.co/settings/tokens"
-        echo "   4. Set: export HF_TOKEN=your_token_here (add to ~/.zshrc)"
+        log_raw "${BOLD}Installing Parakeet TDT (MLX)...${RESET}"
+        pip install mlx-audio >> "$LOG_FILE" 2>&1 && \
+            log_raw "${GREEN}✓ Parakeet / MLX installed${RESET}" || \
+            log_raw "${YELLOW}⚠  Parakeet install failed. You can install it later: pip install mlx-audio${RESET}"
         ;;
     2)
-        echo "Installing Lightning Whisper MLX..."
-        pip install lightning-whisper-mlx -q
+        log_raw "${BOLD}Installing WhisperX...${RESET}"
+        pip install whisperx >> "$LOG_FILE" 2>&1 && \
+            log_raw "${GREEN}✓ WhisperX installed${RESET}" || \
+            fail \
+                "WhisperX installation failed." \
+                "Check the log at $LOG_FILE. You can try 'pip install whisperx' manually after running 'source venv/bin/activate'."
+        log_raw ""
+        log_raw "${YELLOW}Speaker diarization needs a free HuggingFace token:${RESET}"
+        log_raw "  1. Create an account at huggingface.co"
+        log_raw "  2. Accept terms at: huggingface.co/pyannote/speaker-diarization-3.1"
+        log_raw "  3. Get your token at: huggingface.co/settings/tokens"
+        log_raw "  4. Add to your shell: export HF_TOKEN=your_token_here"
         ;;
     3)
-        echo "Installing OpenAI Whisper..."
-        pip install openai-whisper -q
+        log_raw "${BOLD}Installing Lightning Whisper MLX...${RESET}"
+        pip install lightning-whisper-mlx >> "$LOG_FILE" 2>&1 && \
+            log_raw "${GREEN}✓ Lightning Whisper MLX installed${RESET}" || \
+            log_raw "${YELLOW}⚠  Install failed. Try manually: pip install lightning-whisper-mlx${RESET}"
         ;;
     4)
-        echo "Skipping transcription engine. Install later with:"
-        echo "  source venv/bin/activate && pip install whisperx"
+        log_raw "${BOLD}Installing OpenAI Whisper...${RESET}"
+        pip install openai-whisper >> "$LOG_FILE" 2>&1 && \
+            log_raw "${GREEN}✓ OpenAI Whisper installed${RESET}" || \
+            log_raw "${YELLOW}⚠  Install failed. Try manually: pip install openai-whisper${RESET}"
+        ;;
+    5)
+        log_raw "${YELLOW}Skipping transcription engine.${RESET}"
+        log_raw "Install later with: source venv/bin/activate && pip install mlx-audio"
+        ;;
+    *)
+        log_raw "${YELLOW}Unrecognized choice — skipping transcription engine.${RESET}"
         ;;
 esac
 
-echo ""
-echo "══════════════════════════════════════"
-echo "  ✅ Installation complete!"
-echo ""
-echo "  Start the app:  ./start.sh"
-echo "  Then open:       http://localhost:5050"
-echo ""
-echo "  Optional: Set up AI analysis"
-echo "  Local (Ollama):  ollama serve"
-echo "  Cloud (Claude):  export ANTHROPIC_API_KEY=sk-..."
-echo "══════════════════════════════════════"
-echo ""
+# ── Done ──
+log_raw ""
+log_raw "══════════════════════════════════════════"
+log_raw "${GREEN}${BOLD}  ✅ Setup complete!${RESET}"
+log_raw ""
+log_raw "  Start the app:   ${BOLD}./start.sh${RESET}"
+log_raw "  Then open:       ${BOLD}http://localhost:5050${RESET}"
+log_raw ""
+log_raw "  Optional — AI analysis (free, local):"
+log_raw "    brew install ollama"
+log_raw "    ollama serve"
+log_raw "    ollama pull gemma4"
+log_raw ""
+log_raw "  Optional — Cloud AI (higher quality):"
+log_raw "    export ANTHROPIC_API_KEY=sk-ant-..."
+log_raw "══════════════════════════════════════════"
+log_raw ""
+log "  Install log saved to: $LOG_FILE"
+log_raw ""

--- a/uninstall.sh
+++ b/uninstall.sh
@@ -1,0 +1,155 @@
+#!/bin/bash
+# ── Doza Assist Uninstaller ──
+
+cd "$(dirname "$0")"
+
+# ── Colors ──
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+BOLD='\033[1m'
+RESET='\033[0m'
+
+echo ""
+echo "  ╔═══════════════════════════════════════╗"
+echo "  ║      Doza Assist Uninstaller          ║"
+echo "  ╚═══════════════════════════════════════╝"
+echo ""
+echo -e "${YELLOW}This will remove Doza Assist and its setup files.${RESET}"
+echo ""
+echo "  What WILL be removed:"
+echo "    • Python virtual environment (venv)"
+echo "    • Setup state and install logs"
+echo "    • Doza Assist config files"
+echo ""
+echo "  What will NOT be removed:"
+echo "    • Your projects, media files, and transcripts"
+echo "    • Homebrew, Python, or ffmpeg"
+echo "    • Any other apps on your Mac"
+echo ""
+
+read -p "Continue? (y/n): " confirm
+if [[ "$confirm" != "y" && "$confirm" != "Y" ]]; then
+    echo ""
+    echo "Cancelled. Nothing was removed."
+    echo ""
+    exit 0
+fi
+
+echo ""
+
+REMOVED=()
+SKIPPED=()
+
+# ── Remove venv (project root) ──
+if [ -d "venv" ]; then
+    echo -e "  Removing virtual environment..."
+    rm -rf venv
+    REMOVED+=("Python virtual environment (venv)")
+else
+    SKIPPED+=("venv (not found)")
+fi
+
+# ── Remove venv (app support dir, used by .app bundle) ──
+SUPPORT_DIR="$HOME/Library/Application Support/DozaAssist"
+if [ -d "$SUPPORT_DIR/venv" ]; then
+    echo -e "  Removing app support virtual environment..."
+    rm -rf "$SUPPORT_DIR/venv"
+    REMOVED+=("App support virtual environment")
+fi
+
+# ── Remove setup state / config ──
+if [ -f "$SUPPORT_DIR/setup.json" ]; then
+    echo -e "  Removing setup state..."
+    rm -f "$SUPPORT_DIR/setup.json"
+    REMOVED+=("Setup state (setup.json)")
+fi
+
+if [ -f "$SUPPORT_DIR/setup.log" ]; then
+    rm -f "$SUPPORT_DIR/setup.log"
+    REMOVED+=("Setup log")
+fi
+
+# Remove empty support dir if nothing else is in it
+if [ -d "$SUPPORT_DIR" ] && [ -z "$(ls -A "$SUPPORT_DIR" 2>/dev/null)" ]; then
+    rmdir "$SUPPORT_DIR"
+fi
+
+# ── Remove local install log ──
+if [ -f "install_log.txt" ]; then
+    echo -e "  Removing install log..."
+    rm -f install_log.txt
+    REMOVED+=("Install log (install_log.txt)")
+fi
+
+# ── Stop Ollama if running ──
+if pgrep -x "ollama" > /dev/null 2>&1; then
+    echo -e "  Stopping Ollama..."
+    pkill -x ollama 2>/dev/null || true
+    sleep 1
+    REMOVED+=("Ollama process (stopped)")
+elif command -v ollama &>/dev/null; then
+    # Try graceful stop even if pgrep didn't find it
+    ollama stop 2>/dev/null || true
+fi
+
+# ── Optional: remove Ollama + models ──
+echo ""
+echo -e "${YELLOW}Ollama is the AI engine that powers analysis and chat features.${RESET}"
+echo "  Removing it frees up disk space (~3–10 GB) but will also affect"
+echo "  any other apps on your Mac that use Ollama."
+echo ""
+read -p "Remove Ollama and its downloaded AI models? (y/n): " remove_ollama
+
+if [[ "$remove_ollama" == "y" || "$remove_ollama" == "Y" ]]; then
+    # Remove models directory
+    if [ -d "$HOME/.ollama" ]; then
+        echo -e "  Removing Ollama models and data..."
+        rm -rf "$HOME/.ollama"
+        REMOVED+=("Ollama models (~/.ollama)")
+    fi
+
+    # Remove Ollama app / binary
+    if [ -d "/Applications/Ollama.app" ]; then
+        echo -e "  Removing Ollama.app..."
+        rm -rf "/Applications/Ollama.app"
+        REMOVED+=("Ollama.app")
+    fi
+
+    if command -v brew &>/dev/null && brew list ollama &>/dev/null 2>&1; then
+        echo -e "  Uninstalling Ollama via Homebrew..."
+        brew uninstall ollama 2>/dev/null && REMOVED+=("Ollama (Homebrew)") || true
+    elif [ -f "/usr/local/bin/ollama" ]; then
+        rm -f "/usr/local/bin/ollama"
+        REMOVED+=("Ollama binary (/usr/local/bin/ollama)")
+    elif [ -f "/opt/homebrew/bin/ollama" ]; then
+        rm -f "/opt/homebrew/bin/ollama"
+        REMOVED+=("Ollama binary (/opt/homebrew/bin/ollama)")
+    fi
+else
+    SKIPPED+=("Ollama (kept)")
+fi
+
+# ── Summary ──
+echo ""
+echo "  ─────────────────────────────────────"
+echo -e "  ${GREEN}${BOLD}Done! Here's what was removed:${RESET}"
+echo ""
+
+for item in "${REMOVED[@]}"; do
+    echo -e "  ${GREEN}✓${RESET} $item"
+done
+
+if [ ${#SKIPPED[@]} -gt 0 ]; then
+    echo ""
+    echo -e "  ${YELLOW}Skipped (not found or kept):${RESET}"
+    for item in "${SKIPPED[@]}"; do
+        echo "    - $item"
+    done
+fi
+
+echo ""
+echo "  Your projects, media, and transcripts are untouched."
+echo ""
+echo -e "  ${BOLD}To reinstall, run:${RESET} bash install.sh"
+echo ""


### PR DESCRIPTION
…ooting section

- New uninstall.sh: confirms before removing venv, setup state, and config; optionally removes Ollama and models; never touches user project files; prints a clear summary of what was removed
- Improved install.sh: checks Xcode CLT first with guided wait, adds --clean flag to wipe and reinstall, adds colored output, writes all output to install_log.txt, gives actionable error messages with specific next steps
- README: new Troubleshooting section covering --clean, uninstall, Xcode CLT, macOS security prompt, and log file for bug reports