### PR TITLE
story_builder: hardline narrative reorder over chronological default

### DIFF
--- a/ai_analysis.py
+++ b/ai_analysis.py
@@ -2702,7 +2702,9 @@ def build_story(transcript, message, project_name="Interview", segment_vectors=N
 
 Rules:
 - Select clips that build a clear narrative arc: hook, rising action, emotional peak, resolution
-- Order them for maximum story impact, not chronological order unless that serves the story
+- MANDATORY ARC: every selected clip fills exactly one role in this five-slot arc — hook, context, pressure, turn, resolution. Tag the role in editorial_note (e.g. "ROLE: turn — ..."). The "order" field reflects the arc, NOT the timecode.
+- NON-CHRONOLOGICAL BY DEFAULT: the transcript below is presented in recording order; your output MUST NOT preserve that order unless the user explicitly requested chronological OR a clip's meaning depends on temporal sequence (cause→effect chain).
+- ANTI-PATTERN CHECK: if your selected clips' start_time values are monotonically increasing in your chosen order, you have likely defaulted to chronological — re-examine and re-sequence.
 - Each clip should be 5-30 seconds long unless the moment requires more breathing room
 - DURATION IS CRITICAL: If the user requests a specific duration (e.g. "4 minute story"), you MUST hit that target. Calculate the total duration of all clips you select by adding up (end_time - start_time) for each clip. Aim for roughly 3-4 clips per minute. For a 4-minute story, that means 12-16 clips totaling approximately 3:30-4:30 of content. If your first selection is too short, add more clips.
 - For each clip, provide: a short title, start timecode, end timecode, the transcript excerpt, and a one-sentence editorial note explaining why this clip is in this position
@@ -2732,7 +2734,7 @@ PROJECT: {project_name}
 
 USER REQUEST: {message}
 
-TRANSCRIPT:
+TRANSCRIPT (presented in recording order — re-sequence freely for narrative arc):
 {formatted}
 
 Return ONLY valid JSON. No markdown, no extra text."""
@@ -3043,8 +3045,33 @@ def _build_story_from_vectors(segment_vectors, message, project_name, profile_id
     if not candidates:
         candidates = list(segment_vectors)
 
-    menu_lines = []
-    for s in candidates:
+    # Re-order the menu by NARRATIVE WEIGHT before showing it to the model:
+    # high-score segments first, then within each score tier sort by beat in
+    # arc-natural order (hook → context → pressure → turn → resolution). The
+    # default chronological-by-transcript layout was anchoring the model's
+    # output to recording order — small local models pick clips top-to-bottom
+    # and the build came out chronological even though the prompt asked for
+    # narrative ordering. Hydration is seg_id-keyed, so menu order has no
+    # downstream effect.
+    _SCORE_RANK = {'high': 0, 'medium': 1, 'low': 2}
+    _BEAT_RANK = {'hook': 0, 'context': 1, 'pressure': 2, 'turn': 3, 'resolution': 4}
+
+    def _menu_sort_key(s):
+        return (
+            _SCORE_RANK.get((s.get('narrative_score') or 'medium').lower(), 1),
+            _BEAT_RANK.get((s.get('beat_type') or 'context').lower(), 1),
+            s.get('seg_id', ''),
+        )
+
+    ordered = sorted(candidates, key=_menu_sort_key)
+
+    menu_lines = [
+        "# Segments below are listed BY NARRATIVE WEIGHT (high score first, "
+        "then hook/context/pressure/turn/resolution within each tier), "
+        "NOT by recording time. Choose and order purely on story logic.",
+        "",
+    ]
+    for s in ordered:
         dur = _tc_to_sec(s.get('timecode_out', '0:0:0')) - _tc_to_sec(s.get('timecode_in', '0:0:0'))
         menu_lines.append(
             f"- {s.get('seg_id', '?')} [{s.get('timecode_in', '')}-{s.get('timecode_out', '')}] "
@@ -3063,9 +3090,10 @@ Rules:
 - Prioritize segments with narrative_score "high" — those are the spine.
 - Use "episodic" segments (specific events, sensory) for key emotional moments.
 - Use "semantic" segments (general reflection) for context and transitions between episodic beats.
-- Build a clear arc: hook, context, pressure, turn, resolution.
+- MANDATORY ARC: every selected clip fills exactly one role in this five-slot arc — hook, context, pressure, turn, resolution. Tag each clip's role in its editorial_note (e.g. "ROLE: turn — ..."). The "order" field reflects the arc, NOT the timecode.
+- NON-CHRONOLOGICAL BY DEFAULT: the menu is listed by narrative weight, not by recording time. Your output ordering is independent of timecode_in. Re-sequence ruthlessly. Use chronological order only when the user's brief explicitly asks for it OR when a clip's meaning depends on a prior clip's information (cause→effect chain).
+- ANTI-PATTERN CHECK: before you finalize, scan your selected clips' timecode_in values in your chosen order. If they are monotonically increasing (each clip's timecode_in is later than the previous), you have likely failed to reorder for narrative arc — re-examine and re-sequence unless the story genuinely requires the temporal sequence.
 - DURATION IS CRITICAL: If the user requests a specific duration (e.g. "4 minute story"), you MUST hit that target. Calculate the total duration of all clips you select by adding up (end_time - start_time) for each clip. Each segment in the menu shows its timecode range — use that to calculate duration. Aim for roughly 3-4 clips per minute of requested duration. For a 4-minute story, select enough clips to total approximately 3:30-4:30 of content. If your first selection is too short, add more clips. If too long, trim or remove clips.
-- Ordered for story impact (not necessarily chronological).
 - ALWAYS include a "reasoning" field: 2-3 conversational sentences in plain language explaining what this story is really about underneath the surface, why this arc works, and what the emotional spine is. Talk like a doc editor, not a corporate brief. No bullet points.
 - Always respond in valid JSON only. No markdown, no prose outside the JSON."""
 

--- a/tests/test_story_builder.py
+++ b/tests/test_story_builder.py
@@ -199,6 +199,121 @@ class TestStoryBuildMenuPruning:
             assert f'SEG{i:03d}' in captured['prompt']
 
 
+class TestStoryBuildOrdering:
+    """The story builder must rearrange clips into narrative-arc order, not
+    chronological recording order. Two levers carry that:
+      (a) the segment menu shown to the model is sorted by narrative weight
+          (score then beat), so the model can't just pick top-to-bottom and
+          end up chronological;
+      (b) the system prompt mandates an arc and explicitly forbids
+          monotonically-increasing timecodes as a default.
+    """
+
+    def _diverse_vectors(self):
+        # SEG001 is earliest in time but only medium / context.
+        # SEG002 is mid-time, high / turn.
+        # SEG003 is latest in time, high / hook (the spine — should sort first).
+        return [
+            {'seg_id': 'SEG001', 'timecode_in': '00:00:00', 'timecode_out': '00:00:30',
+             'narrative_score': 'medium', 'beat_type': 'context',
+             'memory_type': 'semantic', 'thread_title': 'a',
+             'theme_tags': [], 'transcript_excerpt': 'first'},
+            {'seg_id': 'SEG002', 'timecode_in': '00:01:00', 'timecode_out': '00:01:30',
+             'narrative_score': 'high', 'beat_type': 'turn',
+             'memory_type': 'episodic', 'thread_title': 'b',
+             'theme_tags': [], 'transcript_excerpt': 'mid'},
+            {'seg_id': 'SEG003', 'timecode_in': '00:02:00', 'timecode_out': '00:02:30',
+             'narrative_score': 'high', 'beat_type': 'hook',
+             'memory_type': 'episodic', 'thread_title': 'c',
+             'theme_tags': [], 'transcript_excerpt': 'late'},
+        ]
+
+    def test_menu_groups_by_score_not_timecode(self, monkeypatch):
+        captured = {}
+        monkeypatch.setattr(
+            ai_analysis, '_call_ai',
+            lambda p, s="": (captured.update(prompt=p, system=s), '{"clips": []}')[1],
+        )
+        monkeypatch.setattr(ai_analysis, 'inject_my_style', lambda p, profile_id=None: p)
+
+        ai_analysis._build_story_from_vectors(
+            self._diverse_vectors(), message="build", project_name="T",
+        )
+        prompt = captured['prompt']
+        positions = {sid: prompt.index(sid) for sid in ('SEG001', 'SEG002', 'SEG003')}
+        # high+hook (SEG003) must come before high+turn (SEG002) before medium (SEG001).
+        # That is the OPPOSITE of chronological order.
+        assert positions['SEG003'] < positions['SEG002'] < positions['SEG001'], (
+            f"menu still in chronological order: {positions}"
+        )
+        assert 'BY NARRATIVE WEIGHT' in prompt
+
+    def test_prompt_contains_mandatory_reorder_directive(self, monkeypatch):
+        captured = {}
+
+        def _stub(prompt, system_prompt=""):
+            captured['prompt'] = prompt
+            captured['system'] = system_prompt
+            return '{"clips": []}'
+
+        monkeypatch.setattr(ai_analysis, '_call_ai', _stub)
+        monkeypatch.setattr(ai_analysis, 'inject_my_style', lambda p, profile_id=None: p)
+
+        ai_analysis._build_story_from_vectors(
+            self._diverse_vectors(), message="build", project_name="T",
+        )
+        sys = captured['system']
+        # Directive language and the five arc slots are present.
+        assert 'MANDATORY ARC' in sys
+        assert 'NON-CHRONOLOGICAL BY DEFAULT' in sys
+        assert 'monotonically increasing' in sys
+        for slot in ('hook', 'context', 'pressure', 'turn', 'resolution'):
+            assert slot in sys, f"missing arc slot {slot!r} from prompt"
+        # Old permissive language must be gone — it was ignored by small models.
+        assert 'not necessarily chronological' not in sys
+
+    def test_non_chronological_order_preserved_through_hydration(self, monkeypatch):
+        vectors = [
+            {'seg_id': 'SEG_A', 'timecode_in': '00:00:00', 'timecode_out': '00:00:30',
+             'narrative_score': 'high', 'beat_type': 'context',
+             'memory_type': 'semantic', 'thread_title': 'a',
+             'theme_tags': [], 'transcript_excerpt': 'a'},
+            {'seg_id': 'SEG_B', 'timecode_in': '00:05:00', 'timecode_out': '00:05:30',
+             'narrative_score': 'high', 'beat_type': 'hook',
+             'memory_type': 'episodic', 'thread_title': 'b',
+             'theme_tags': [], 'transcript_excerpt': 'b'},
+            {'seg_id': 'SEG_C', 'timecode_in': '00:10:00', 'timecode_out': '00:10:30',
+             'narrative_score': 'high', 'beat_type': 'turn',
+             'memory_type': 'episodic', 'thread_title': 'c',
+             'theme_tags': [], 'transcript_excerpt': 'c'},
+        ]
+        # Model picks B (later) first as the hook, then A as context, then C as turn —
+        # an arc that runs against chronology.
+        fake_response = json.dumps({
+            'story_title': 'X', 'target_duration': '1m', 'reasoning': 'r',
+            'clips': [
+                {'order': 1, 'seg_id': 'SEG_B', 'editorial_note': 'ROLE: hook'},
+                {'order': 2, 'seg_id': 'SEG_A', 'editorial_note': 'ROLE: context'},
+                {'order': 3, 'seg_id': 'SEG_C', 'editorial_note': 'ROLE: turn'},
+            ],
+        })
+        monkeypatch.setattr(ai_analysis, '_call_ai', lambda p, s="": fake_response)
+        monkeypatch.setattr(ai_analysis, 'inject_my_style', lambda p, profile_id=None: p)
+
+        out = ai_analysis._build_story_from_vectors(
+            vectors, message="x", project_name="T",
+        )
+        seg_ids = [c['seg_id'] for c in out['clips']]
+        assert seg_ids == ['SEG_B', 'SEG_A', 'SEG_C']  # NOT chronological
+        # Hydration filled timecodes from the segment vector by seg_id, not from
+        # the (stripped) model echo.
+        assert out['clips'][0]['start_time'] == '00:05:00'
+        assert out['clips'][1]['start_time'] == '00:00:00'
+        assert out['clips'][2]['start_time'] == '00:10:00'
+        # order field reflects the arc, not the timecode.
+        assert [c['order'] for c in out['clips']] == [1, 2, 3]
+
+
 class TestStoryBuildEndpoint:
     def test_auto_generates_vectors_when_missing(self, client, transcribed_project, monkeypatch):
         # No segment_vectors.json on disk. The endpoint should call


### PR DESCRIPTION
## Summary
- The story builder's vector-path menu was listed in transcript order and the prompt's "not necessarily chronological" was permissive enough that small local models defaulted to picking clips top-to-bottom — builds came out chronological even when the user's brief wanted an arc.
- Fix attacks both layers:
  - **Menu sort:** segments now ordered by `(narrative_score, beat_type, seg_id)` with a header line announcing it's BY NARRATIVE WEIGHT, not recording time. Hydration is `seg_id`-keyed so menu order has zero downstream effect on exports or persistence.
  - **Prompt directives:** replaced the permissive bullet with three rules — `MANDATORY ARC` (every clip fills a hook/context/pressure/turn/resolution slot, role tagged in `editorial_note`), `NON-CHRONOLOGICAL BY DEFAULT`, and an `ANTI-PATTERN CHECK` warning on monotonically-increasing timecodes.
- Same three directives applied to the raw-transcript fallback path; that user prompt now labels the transcript as `presented in recording order — re-sequence freely for narrative arc`.

## Verification
- 11/11 tests in `tests/test_story_builder.py` pass — added `TestStoryBuildOrdering` with three new tests:
  - `test_menu_groups_by_score_not_timecode` — high+hook segment precedes high+turn precedes medium in the prompt regardless of timecode.
  - `test_prompt_contains_mandatory_reorder_directive` — directive language present, old "not necessarily chronological" gone.
  - `test_non_chronological_order_preserved_through_hydration` — out-of-timecode-order clips survive hydration with timecodes pulled correctly by `seg_id`.
- End-to-end smoke against gemma4 + a real 59-segment project: returned 5 clips with explicit `ROLE:` tags and timecodes `31s → 175s → 126s → 872s → 808s` — non-monotonic in chosen order.

## Test plan
- [ ] Pull this branch and run `pytest tests/test_story_builder.py -v`
- [ ] Build the OSS DMG (`bash build_launcher.sh`), launch the app
- [ ] Open a project with existing `segment_vectors.json`, hit Build with any prompt
- [ ] Inspect the rendered clip cards: `start_time` values should NOT be monotonically increasing across the order; each `editorial_note` should start with `ROLE: <hook|context|pressure|turn|resolution>`

🤖 Generated with [Claude Code](https://claude.com/claude-code)