### PR TITLE
Add preserveBrush opt to transcriptInit

### DIFF
--- a/static/transcript.js
+++ b/static/transcript.js
@@ -284,6 +284,13 @@ function saveLabels() {
  *   labeledSections: list of { start, end, color, text? } from server
  *   segmentVectors:  list of segment vectors for narrative-score
  *                    badges (optional; pass [] when absent)
+ *   preserveBrush:   bool. When true, skip the activeBrush reset and
+ *                    keep whatever color is currently selected (plus
+ *                    the painting-mode body class + active swatch).
+ *                    Used by the Pro Collections Transcript tab on
+ *                    interview swap — the editor's brush choice
+ *                    persists across interviews. Default false (first
+ *                    load behavior: brush starts on 'blue').
  *
  * Resets all in-memory state to the supplied values, restores swatch
  * label inputs, repaints highlights, refreshes the section count,
@@ -317,13 +324,17 @@ function transcriptInit(opts) {
     });
 
     // Auto-activate first swatch + painting mode (preserves the
-    // existing default-on UX from the inline implementation).
-    activeBrush = 'blue';
-    document.body.classList.add('painting-mode');
-    document.body.setAttribute('data-brush', 'blue');
-    document.querySelectorAll('.label-swatch').forEach(s => s.classList.remove('active'));
-    const firstSwatch = document.querySelector('.label-swatch[data-color="blue"]');
-    if (firstSwatch) firstSwatch.classList.add('active');
+    // existing default-on UX from the inline implementation). Skipped
+    // when the caller passes preserveBrush:true — the previously-
+    // selected brush stays active across the call.
+    if (!opts.preserveBrush) {
+        activeBrush = 'blue';
+        document.body.classList.add('painting-mode');
+        document.body.setAttribute('data-brush', 'blue');
+        document.querySelectorAll('.label-swatch').forEach(s => s.classList.remove('active'));
+        const firstSwatch = document.querySelector('.label-swatch[data-color="blue"]');
+        if (firstSwatch) firstSwatch.classList.add('active');
+    }
 
     // Repaint highlights against whatever .tw words are currently in
     // the DOM (the host page is responsible for `allWords` being


### PR DESCRIPTION
Lets callers re-init the transcript module without resetting the active color brush. The Pro Collections Transcript tab uses this on interview switch — the editor's color choice should persist across interviews even though labelSections/colorLabels are loaded fresh from the new project. Default behaviour unchanged (brush resets to 'blue' on first load), which is what project.html relies on.