### PR TITLE
Add CLA and Commercial Version section to README

### DIFF
--- a/CLA.md
+++ b/CLA.md
@@ -1,0 +1,11 @@
+# Doza Assist Contributor License Agreement
+
+By submitting a contribution to this project, you agree that:
+
+1. You are legally entitled to grant the license below.
+2. You grant Doza Visuals LLC a perpetual, worldwide, non-exclusive, royalty-free, irrevocable license to use, reproduce, modify, distribute, sublicense, and relicense your contribution as part of the Doza Assist project, including in proprietary derivative works.
+3. Your contribution is your original work, or you have the right to submit it under the terms of this agreement.
+4. You understand the project is dual-licensed: the open-source version under MIT, and commercial derivative works under proprietary terms.
+
+Signed: ________________________________ Date: __________
+GitHub username: _________________________

--- a/README.md
+++ b/README.md
@@ -383,3 +383,11 @@ Users are responsible for complying with the licenses of any models they downloa
 ---
 
 Built by [Doza Visuals](https://dozavisuals.com)
+
+---
+
+## Commercial Version
+
+The signed Mac app is a proprietary derivative work of this open-source core, licensed separately. One-click install, bundled models, auto-updates, and priority support.
+
+Visit [dozavisuals.com/doza-assist](https://dozavisuals.com/doza-assist) for the paid version.


### PR DESCRIPTION
## Summary
- Add `CLA.md` at the repo root — required for the dual-license model so contributions can be relicensed into the proprietary commercial wrapper.
- Append a `## Commercial Version` section to the bottom of `README.md` pointing to dozavisuals.com/doza-assist for the signed Mac app.

This pair of changes sets up the dual-license posture before CLA Assistant is wired up to enforce signing on incoming PRs.

## Test plan
- [x] Diff review: only `CLA.md` (new) and `README.md` (8 lines appended) are touched
- [ ] Verify `CLA.md` renders correctly on github.com once merged
- [ ] Confirm the `Commercial Version` link in README resolves
- [ ] After merge: install [CLA Assistant](https://github.com/apps/cla-assistant) and point at `https://github.com/DozaVisuals/doza-assist/blob/main/CLA.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)