### PR TITLE
fix: errorhandler no longer masks real exceptions (issue #25)

### DIFF
--- a/app.py
+++ b/app.py
@@ -29,6 +29,12 @@ from doza_assist.fcpxml.timeline_audio import (
 )
 import preferences as prefs
 
+# Hoisted from the global errorhandler to fail loud at server start if the
+# ``ai_providers`` package is missing from the bundle, instead of starting
+# Flask and then having every 500 response mask the real error with a
+# secondary ``ModuleNotFoundError`` from the lazy import (see issue #25).
+from ai_providers import ProviderError
+
 
 def get_project_platform(project: dict) -> str:
     """Return the project's editing platform, falling back to the global default."""
@@ -509,10 +515,16 @@ def _provider_error_response(e):
 
 @app.errorhandler(Exception)
 def _handle_provider_error(e):
-    from ai_providers import ProviderError
-    if not isinstance(e, ProviderError):
-        raise e
-    return _provider_error_response(e)
+    # Defense-in-depth: if anything in the ProviderError branch ever raises
+    # (e.g. jsonify fails on something exotic), re-raise the ORIGINAL
+    # exception so Flask logs the real cause. Otherwise the secondary error
+    # masks the root cause in server.log — exactly the bug from issue #25.
+    if isinstance(e, ProviderError):
+        try:
+            return _provider_error_response(e)
+        except Exception:
+            pass
+    raise e
 
 
 # ── BYO API key: provider settings ──────────────────────────────────

--- a/build_launcher.sh
+++ b/build_launcher.sh
@@ -76,6 +76,7 @@ echo "4. Bundling application files..."
 rsync -a \
     --exclude='.git' \
     --exclude='.gitignore' \
+    --exclude='.claude' \
     --exclude='.DS_Store' \
     --exclude='__pycache__' \
     --exclude='*.pyc' \
@@ -108,6 +109,42 @@ rsync -a \
     --exclude='/*.jpeg' \
     --exclude='/*.xmp' \
     "${SCRIPT_DIR}/" "${APP_SRC_DIR}/"
+
+# Sanity check: every critical package/dir must be in the bundle. If the
+# rsync ever quietly drops one (a future denylist edit, a permissions
+# glitch, an exotic file mode), abort here instead of shipping a DMG that
+# 500s on every request — the failure mode behind issue #25.
+echo ""
+echo "   Verifying critical bundle contents..."
+REQUIRED_PATHS=(
+    "ai_providers/__init__.py"
+    "ai_providers/base.py"
+    "doza_assist/__init__.py"
+    "doza_assist/fcpxml/__init__.py"
+    "exporters/__init__.py"
+    "templates"
+    "static"
+    "app.py"
+    "ai_analysis.py"
+    "preferences.py"
+    "requirements.txt"
+)
+MISSING_FROM_BUNDLE=()
+for p in "${REQUIRED_PATHS[@]}"; do
+    if [ ! -e "${APP_SRC_DIR}/${p}" ]; then
+        MISSING_FROM_BUNDLE+=("$p")
+    fi
+done
+if [ "${#MISSING_FROM_BUNDLE[@]}" -gt 0 ]; then
+    echo ""
+    echo "   BUILD ABORTED — required paths missing from bundle:"
+    for p in "${MISSING_FROM_BUNDLE[@]}"; do
+        echo "     - ${p}"
+    done
+    echo ""
+    echo "   Check the rsync denylist above for a regression."
+    exit 1
+fi
 
 # Make scripts executable
 chmod +x "${APP_SRC_DIR}/setup_runner.sh"

--- a/doza_assist/__init__.py
+++ b/doza_assist/__init__.py
@@ -1,3 +1,3 @@
 """Doza Assist core package."""
 
-__version__ = "3.5.2"
+__version__ = "3.5.3"

--- a/launcher.sh
+++ b/launcher.sh
@@ -45,18 +45,28 @@ log() {
 
 # ── Helpers ──
 
-# Show an error dialog that includes the last 15 lines of a log file, so the
+# Show an error dialog that includes the last 50 lines of a log file, so the
 # user can diagnose without having to open Application Support themselves.
+# If the log mentions ``ModuleNotFoundError``, prepend an actionable hint —
+# that error in server.log almost always means the .app bundle is missing a
+# Python package (issue #25) and the right answer is to re-download.
 show_error_dialog() {
     local message="$1"
     local log_path="${2:-}"
+
+    if [ -n "$log_path" ] && [ -f "$log_path" ] && grep -q "ModuleNotFoundError" "$log_path" 2>/dev/null; then
+        message="$message
+
+This usually means the Doza Assist install is incomplete. Please re-download the latest DMG from:
+https://github.com/DozaVisuals/doza-assist/releases"
+    fi
 
     /usr/bin/osascript <<APPLESCRIPT 2>/dev/null || true
 set dialogText to "$message"
 set logPath to "$log_path"
 if logPath is not "" then
     try
-        set logTail to do shell script "/usr/bin/tail -15 " & quoted form of logPath & " 2>/dev/null || true"
+        set logTail to do shell script "/usr/bin/tail -50 " & quoted form of logPath & " 2>/dev/null || true"
         if logTail is not "" then
             set dialogText to dialogText & "
 

--- a/tests/test_error_handler.py
+++ b/tests/test_error_handler.py
@@ -1,0 +1,80 @@
+"""Tests for the global ``@app.errorhandler(Exception)`` handler.
+
+The handler at ``app._handle_provider_error`` is on the hot path for every
+unhandled exception in every route. Two regression guards live here:
+
+1. ``ProviderError`` instances must come back as JSON 400, not 500 — that's
+   what surfaces the "fix your API key" UI in the frontend.
+
+2. Every other exception type must be re-raised with its identity intact,
+   so Flask's normal 500 logging records the ORIGINAL traceback. The
+   handler must NEVER swallow or substitute the exception — that was the
+   bug in issue #25, where a lazy ``from ai_providers import ProviderError``
+   inside the handler raised ``ModuleNotFoundError`` and masked the real
+   root cause in ``server.log``.
+"""
+
+import os
+import sys
+import tempfile
+
+import pytest
+
+
+@pytest.fixture(scope='module')
+def app_module():
+    # Point DOZA_DATA_DIR at a tempdir so importing app.py doesn't create
+    # projects/ / exports/ inside the repo.
+    tmp = tempfile.mkdtemp(prefix='doza-test-handler-')
+    os.environ['DOZA_DATA_DIR'] = tmp
+    repo_root = os.path.abspath(os.path.join(os.path.dirname(__file__), '..'))
+    if repo_root not in sys.path:
+        sys.path.insert(0, repo_root)
+    import app
+    return app
+
+
+def test_provider_error_returns_400_json(app_module):
+    """A ProviderError flowing through the handler becomes JSON 400."""
+    with app_module.app.test_request_context():
+        result = app_module._handle_provider_error(
+            app_module.ProviderError('missing key', code='no_key')
+        )
+    resp, status = result
+    assert status == 400
+    body = resp.get_json()
+    assert body['code'] == 'no_key'
+    assert body['error'] == 'missing key'
+    assert body['settings_url'] == '/settings'
+
+
+def test_non_provider_error_is_reraised(app_module):
+    """Any non-ProviderError exception must propagate unchanged.
+
+    The class identity AND the message must survive so Flask's normal
+    error logger records the real traceback.
+    """
+    original = ValueError('original-error-marker-xyz')
+    with app_module.app.test_request_context():
+        with pytest.raises(ValueError) as excinfo:
+            app_module._handle_provider_error(original)
+    # Same instance, same message — handler did NOT substitute a new error.
+    assert excinfo.value is original
+    assert 'original-error-marker-xyz' in str(excinfo.value)
+
+
+def test_provider_error_class_imported_at_top_level(app_module):
+    """Guard against the lazy-import regression from issue #25.
+
+    ``ProviderError`` must be a module-level attribute of ``app`` so that
+    a missing ``ai_providers`` package causes server startup to fail
+    loudly (in server.log, before Flask binds the port), rather than
+    starting Flask and masking every 500 response with a secondary
+    ``ModuleNotFoundError`` from inside the handler.
+    """
+    assert hasattr(app_module, 'ProviderError'), (
+        "ProviderError must be imported at the top of app.py — "
+        "see issue #25 for why."
+    )
+    from ai_providers import ProviderError as PE
+    assert app_module.ProviderError is PE


### PR DESCRIPTION
## Summary

Fixes [#25](https://github.com/DozaVisuals/doza-assist/issues/25). The global `@app.errorhandler(Exception)` lazy-imported `ProviderError` from inside the handler — if that import ever raised, the resulting `ModuleNotFoundError` replaced the original exception in `server.log`, masking the real root cause.

- Hoist `from ai_providers import ProviderError` to top-level imports. Fails loud at startup if the bundle is incomplete, instead of starting Flask and 500-ing every request with a misleading secondary error.
- Make `_handle_provider_error` exception-proof — re-raises the original `e` if anything inside the handler ever throws.
- Add `tests/test_error_handler.py` with three regression guards (JSON-400, re-raise, top-level import).
- `build_launcher.sh`: post-rsync existence check for `ai_providers/`, `doza_assist/`, `exporters/`, `templates/`, `static/`, `app.py`, etc. — build aborts if any are missing. Also adds `--exclude='.claude'` to keep worktrees out of the DMG.
- `launcher.sh`: error dialog tails 50 lines instead of 15 and prepends a "re-download the DMG" hint when `server.log` contains `ModuleNotFoundError`.
- Bumps to 3.5.3.

## Test plan

- [x] `pytest tests/test_error_handler.py` passes (3/3)
- [x] `build_launcher.sh` smoke-tests the bundled app cleanly with the hoisted import
- [x] Signed/notarized/stapled DMG built; Gatekeeper accepts on fresh Mac

🤖 Generated with [Claude Code](https://claude.com/claude-code)