### PR TITLE
fix: dashboard renders when doza_assist.__version__ is unimportable (issue #25)

### DIFF
--- a/app.py
+++ b/app.py
@@ -89,8 +89,26 @@ def inject_brand():
     the environment before spawning python -- the shell is responsible
     for ensuring whatever URL it points at actually serves an image
     (drop the logo into static/ before launch).
+
+    The version import is wrapped because a stale or wrong ``doza_assist``
+    package on sys.path (e.g. shadowed by an old pip install in the user's
+    venv) can make ``__version__`` unimportable even on a v3.5.3+ bundle —
+    and an ImportError here crashes every dashboard render, which leaves
+    Flask half-alive and the port stuck (issue #25). Reading the version
+    as "unknown" is a much better failure mode than the app refusing to
+    launch.
     """
-    from doza_assist import __version__ as _doza_version
+    try:
+        from doza_assist import __version__ as _doza_version
+    except (ImportError, AttributeError) as e:
+        print(
+            f"WARNING: could not read doza_assist.__version__ ({type(e).__name__}: {e}). "
+            "App will render with version='unknown'. This usually means a stale or "
+            "shadowed doza_assist package on sys.path — check the venv at "
+            "~/Library/Application Support/DozaAssist/venv for an old install.",
+            flush=True,
+        )
+        _doza_version = 'unknown'
     return {
         'brand': os.environ.get('DOZA_BRAND', 'Doza Assist'),
         'logo_url': os.environ.get('DOZA_LOGO_URL', '/static/logo.jpg'),


### PR DESCRIPTION
## Summary

Defensive fix for [issue #25](https://github.com/DozaVisuals/doza-assist/issues/25). User on v3.5.3 reported `ImportError: cannot import name '__version__' from 'doza_assist'` despite the v3.5.3 source clearly exporting it — suggesting a stale/shadowed `doza_assist` package on sys.path (likely an old pip install in their venv from earlier `install.sh --clean` runs).

The blast radius was outsized: `inject_brand` is a Flask context processor, so the import crashed every page render and left Flask half-alive — which is why the user also had to manually `kill` the orphaned Python process before the next launch (port 5050 stuck).

This PR wraps the import in `try`/`except`. If `__version__` can't be loaded, the dashboard reads it as `"unknown"` and the app launches, with a clear WARNING line in `server.log` pointing at the likely cause.

## What this doesn't fix

The user still has a stale package on their machine. Diagnosing that root cause is in flight on the [issue thread](https://github.com/DozaVisuals/doza-assist/issues/25#issuecomment-4503662382) (asked them for the bundled file contents + a `find` over their venv). This PR is the safety net so a future user with a similar sys.path collision doesn't get a fully unlaunchable app.

## Test plan

- [ ] Normal install where `doza_assist/__version__` is importable → dashboard shows the real version (unchanged behavior).
- [ ] Simulate the failure: `python -c "import sys; sys.modules['doza_assist'] = type(sys)('doza_assist')"` before importing `app` → dashboard renders, version reads as `"unknown"`, server.log shows the WARNING.
- [ ] Port 5050 stays free across restarts (no half-alive Flask process from a crashed render).

🤖 Generated with [Claude Code](https://claude.com/claude-code)