### PR TITLE
release: bump version to 3.5.4

### DIFF
--- a/doza_assist/__init__.py
+++ b/doza_assist/__init__.py
@@ -1,3 +1,3 @@
 """Doza Assist core package."""
 
-__version__ = "3.5.3"
+__version__ = "3.5.4"


### PR DESCRIPTION
Roll-up release for #25 (defensive __version__ fallback) and #28 (multi-speaker routing fix). Both fixes have already landed on main; this just bumps the version string before tagging.