### PR TITLE
fix: FCPXML honors embedded source timecode (DJI import, follow-up to #34)

### DIFF
--- a/app.py
+++ b/app.py
@@ -19,7 +19,9 @@ from flask import Flask, render_template, request, jsonify, send_file, redirect,
 from werkzeug.utils import secure_filename
 
 from exporters import get_exporter, PLATFORMS, DEFAULT_PLATFORM
-from exporters.media_probe import get_video_resolution, get_video_framerate
+from exporters.media_probe import (
+    get_video_resolution, get_video_framerate, get_video_start_timecode_frames,
+)
 from doza_assist.fcpxml import (
     parse_fcpxml, ParseError, Select, WriterError,
     write_selects_as_new_project, write_markers_on_timeline,
@@ -2188,6 +2190,9 @@ def _build_nle_export(project: dict, body: dict, force_platform: str | None = No
     framerate = detected_fps or body.get('framerate', 23.976)
     export_mode = body.get('mode', 'cuts')  # 'cuts', 'markers', 'both'
     width, height = get_video_resolution(source_path)
+    # Embedded start timecode (DJI/Sony stamp time-of-day TC); FCP rejects edits
+    # exported as 0-based against such media.
+    start_tc_frames = get_video_start_timecode_frames(source_path, framerate)
     total_clips = body.get('total_clips', len(markers)) or len(markers)
 
     if force_platform and force_platform in PLATFORMS:
@@ -2210,6 +2215,7 @@ def _build_nle_export(project: dict, body: dict, force_platform: str | None = No
         exports_dir=app.config['EXPORTS_DIR'],
         export_mode=export_mode,
         total_clips=total_clips,
+        start_tc_frames=start_tc_frames,
     )
     return result, exporter
 
@@ -3062,6 +3068,7 @@ def _build_nle_story_export(project, body, force_platform=None):
     width, height = get_video_resolution(source_path)
     detected_fps = get_video_framerate(source_path)
     framerate = detected_fps or body.get('framerate', 23.976)
+    start_tc_frames = get_video_start_timecode_frames(source_path, framerate)
 
     if force_platform and force_platform in PLATFORMS:
         platform = force_platform
@@ -3080,6 +3087,7 @@ def _build_nle_story_export(project, body, force_platform=None):
         width=width,
         height=height,
         exports_dir=app.config['EXPORTS_DIR'],
+        start_tc_frames=start_tc_frames,
     )
     return result, exporter
 

--- a/doza_assist/__init__.py
+++ b/doza_assist/__init__.py
@@ -1,3 +1,3 @@
 """Doza Assist core package."""
 
-__version__ = "3.5.6"
+__version__ = "3.5.7"

--- a/exporters/base.py
+++ b/exporters/base.py
@@ -53,6 +53,7 @@ class BaseExporter(ABC):
         exports_dir: str,
         export_mode: str = "cuts",
         total_clips: int = 0,
+        start_tc_frames: int = 0,  # media's embedded start timecode, in frames
     ) -> ExportResult:
         """Export a flat list of marker/clip dicts."""
 
@@ -69,5 +70,6 @@ class BaseExporter(ABC):
         width: int,
         height: int,
         exports_dir: str,
+        start_tc_frames: int = 0,  # media's embedded start timecode, in frames
     ) -> ExportResult:
         """Export an assembled story builder sequence as a timeline."""

--- a/exporters/edl.py
+++ b/exporters/edl.py
@@ -144,6 +144,7 @@ class EDLExporter(BaseExporter):
         exports_dir,
         export_mode="cuts",
         total_clips=0,
+        start_tc_frames=0,  # accepted for interface parity (see note in export_story)
     ) -> ExportResult:
         if export_type == "labels" and len(markers) == 1:
             suffix = (markers[0].get("text") or "Clip")[:40].strip()
@@ -205,6 +206,7 @@ class EDLExporter(BaseExporter):
         width,
         height,
         exports_dir,
+        start_tc_frames=0,  # accepted for interface parity; source TC handling is a TODO for EDL
     ) -> ExportResult:
         # Story markers may carry an _order field; preserve it the way the
         # FCPXML story exporter does.

--- a/exporters/fcpxml.py
+++ b/exporters/fcpxml.py
@@ -72,6 +72,7 @@ class FCPXMLExporter(BaseExporter):
         exports_dir,
         export_mode="cuts",
         total_clips=0,
+        start_tc_frames=0,
     ) -> ExportResult:
         content = generate_fcpxml(
             markers=markers,
@@ -82,6 +83,7 @@ class FCPXMLExporter(BaseExporter):
             mode=export_mode,
             width=width,
             height=height,
+            start_tc_frames=start_tc_frames,
         )
 
         filename = _compose_marker_filename(
@@ -112,6 +114,7 @@ class FCPXMLExporter(BaseExporter):
         width,
         height,
         exports_dir,
+        start_tc_frames=0,
     ) -> ExportResult:
         content = generate_story_fcpxml(
             markers=markers,
@@ -122,6 +125,7 @@ class FCPXMLExporter(BaseExporter):
             media_duration=media_duration,
             width=width,
             height=height,
+            start_tc_frames=start_tc_frames,
         )
 
         filename = (

--- a/exporters/media_probe.py
+++ b/exporters/media_probe.py
@@ -7,6 +7,7 @@ two places; now it lives here and both routes call into it.
 """
 
 import os
+import re
 import shutil
 import subprocess
 
@@ -88,3 +89,64 @@ def get_video_framerate(path: str) -> float | None:
     except Exception:
         pass
     return None
+
+
+_TIMECODE_RE = re.compile(r"^(\d+):(\d+):(\d+)([:;])(\d+)$")
+
+
+def timecode_to_frames(tc: str, framerate: float) -> int | None:
+    """Convert an SMPTE timecode string ("HH:MM:SS:FF", or ";"/"." for
+    drop-frame) to a whole-frame count on the framerate's grid. Returns None if
+    the string isn't a timecode.
+
+    Frames are counted at the nominal integer rate (29.97 -> 30, 23.976 -> 24).
+    Drop-frame (`;`) drops 2 frames per minute except every tenth minute (4 at
+    59.94). This frame index is exactly what FCP stores as an asset's source
+    timecode: asset.start = frames * frameDuration."""
+    m = _TIMECODE_RE.match((tc or "").strip())
+    if not m:
+        return None
+    hh, mm, ss, sep, ff = (int(m.group(1)), int(m.group(2)), int(m.group(3)),
+                           m.group(4), int(m.group(5)))
+    nominal = int(round(framerate))
+    if nominal <= 0:
+        return None
+    total = ((hh * 3600 + mm * 60 + ss) * nominal) + ff
+    if sep == ";" and nominal % 30 == 0:
+        drop_per_min = 2 * (nominal // 30)
+        minutes = hh * 60 + mm
+        total -= drop_per_min * (minutes - minutes // 10)
+    return total
+
+
+def get_video_start_timecode_frames(path: str, framerate: float) -> int:
+    """Return the media's embedded start timecode in whole frames (0 if none).
+
+    DJI, Sony, and many cameras stamp time-of-day timecode. Final Cut keys an
+    asset's source timecode off it, so an FCPXML that exports 0-based edits
+    against such media is rejected with "Invalid edit with no respective media"
+    — the edits fall outside the media's real timecode range. Reads the
+    `timecode` tag from the format or any stream (e.g. a `tmcd` track)."""
+    if not path or not os.path.exists(path):
+        return 0
+    ffprobe = _find_ffprobe()
+    if not ffprobe:
+        return 0
+    try:
+        result = subprocess.run(
+            [
+                ffprobe, "-v", "quiet",
+                "-show_entries", "format_tags=timecode:stream_tags=timecode",
+                "-of", "default=nw=1:nk=1",
+                path,
+            ],
+            capture_output=True, text=True, timeout=10,
+        )
+        if result.returncode == 0:
+            for line in result.stdout.splitlines():
+                frames = timecode_to_frames(line.strip(), framerate)
+                if frames:
+                    return frames
+    except Exception:
+        pass
+    return 0

--- a/exporters/premiere_xml.py
+++ b/exporters/premiere_xml.py
@@ -282,6 +282,7 @@ class PremiereXMLExporter(BaseExporter):
         exports_dir,
         export_mode="cuts",
         total_clips=0,
+        start_tc_frames=0,  # accepted for interface parity; Premiere uses 0-based file in/out
     ) -> ExportResult:
         if export_type == "labels" and len(markers) == 1:
             suffix = (markers[0].get("text") or "Clip")[:40].strip()
@@ -345,6 +346,7 @@ class PremiereXMLExporter(BaseExporter):
         width,
         height,
         exports_dir,
+        start_tc_frames=0,  # accepted for interface parity; Premiere uses 0-based file in/out
     ) -> ExportResult:
         ordered = sorted(
             (m for m in markers if (m.get("end") or 0) > (m.get("start") or 0)),

--- a/fcpxml_export.py
+++ b/fcpxml_export.py
@@ -88,7 +88,7 @@ MARKER_COLORS = {
 
 def generate_fcpxml(markers, project_name="Interview", framerate=23.976,
                     source_path=None, media_duration=None, mode="cuts",
-                    width=1920, height=1080):
+                    width=1920, height=1080, start_tc_frames=0):
     """
     Generate an FCPXML file.
 
@@ -111,12 +111,22 @@ def generate_fcpxml(markers, project_name="Interview", framerate=23.976,
         return _generate_markers_only(markers, project_name, framerate, width, height)
 
     return _generate_cuts_timeline(markers, project_name, framerate,
-                                   source_path, media_duration, mode, width, height)
+                                   source_path, media_duration, mode, width, height,
+                                   start_tc_frames)
 
 
 def _generate_cuts_timeline(markers, project_name, framerate, source_path,
-                            media_duration, mode, width=1920, height=1080):
-    """Generate FCPXML with actual cuts on the timeline referencing source media."""
+                            media_duration, mode, width=1920, height=1080,
+                            start_tc_frames=0):
+    """Generate FCPXML with actual cuts on the timeline referencing source media.
+
+    ``start_tc_frames`` is the media's embedded start timecode in whole frames.
+    Final Cut keys an asset's source timecode off the media's real timecode, so
+    every source-side time (the asset ``start`` and each clip/keyword ``start``)
+    must be expressed relative to it. Cameras like DJI and Sony stamp
+    time-of-day timecode; exporting 0-based edits against such media makes FCP
+    reject every clip with "Invalid edit with no respective media."
+    """
     frame_dur = get_frame_duration(framerate)
     safe_name = _escape_xml(project_name)
     uid = f"doza-{uuid.uuid4().hex[:8]}"
@@ -161,7 +171,9 @@ def _generate_cuts_timeline(markers, project_name, framerate, source_path,
             continue
 
         offset_str = frames_to_fcpxml_time(offset_frames, framerate)
-        src_start_str = frames_to_fcpxml_time(start_f, framerate)
+        # Source-side times are absolute in the asset's timecode space:
+        # embedded start TC + the in-point offset into the media.
+        src_start_str = frames_to_fcpxml_time(start_tc_frames + start_f, framerate)
         dur_str = frames_to_fcpxml_time(dur_f, framerate)
 
         clip_name = _escape_xml(m.get('text', f'Clip {i+1}'))[:80]
@@ -200,13 +212,17 @@ def _generate_cuts_timeline(markers, project_name, framerate, source_path,
 
     timeline_dur_str = frames_to_fcpxml_time(offset_frames or media_frames, framerate)
 
+    # The asset's source timecode origin = the media's embedded start TC. FCP
+    # validates every clip's start against [asset.start, asset.start+duration].
+    asset_start_str = frames_to_fcpxml_time(start_tc_frames, framerate) if start_tc_frames else "0/1s"
+
     fcpxml = f"""<?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE fcpxml>
 
 <fcpxml version="1.11">
     <resources>
         <format id="r1" name="{_format_name(width, height, framerate)}" frameDuration="{frame_dur}" width="{width}" height="{height}" colorSpace="1-1-1 (Rec. 709)"/>
-        <asset id="r2" name="{_escape_xml(os.path.basename(source_path))}" start="0/1s" duration="{media_dur_str}" hasVideo="{1 if is_video else 0}" hasAudio="1" format="r1">
+        <asset id="r2" name="{_escape_xml(os.path.basename(source_path))}" start="{asset_start_str}" duration="{media_dur_str}" hasVideo="{1 if is_video else 0}" hasAudio="1" format="r1">
             <media-rep kind="original-media" src="{file_url}"/>
         </asset>
     </resources>
@@ -228,7 +244,7 @@ def _generate_cuts_timeline(markers, project_name, framerate, source_path,
 
 def generate_story_fcpxml(markers, project_name="Interview", story_title="Story",
                           framerate=23.976, source_path=None, media_duration=None,
-                          width=1920, height=1080):
+                          width=1920, height=1080, start_tc_frames=0):
     """
     Generate FCPXML for a Story Builder sequence.
     Creates a single timeline with clips in narrative order as actual edits.
@@ -268,7 +284,8 @@ def generate_story_fcpxml(markers, project_name="Interview", story_title="Story"
             continue
 
         offset_str = frames_to_fcpxml_time(offset_frames, framerate)
-        src_start_str = frames_to_fcpxml_time(start_f, framerate)
+        # Absolute source time = embedded start TC + in-point into the media.
+        src_start_str = frames_to_fcpxml_time(start_tc_frames + start_f, framerate)
         dur_str = frames_to_fcpxml_time(dur_f, framerate)
 
         clip_name = _escape_xml(m.get('text', f'Clip {i+1}'))[:80]
@@ -293,13 +310,15 @@ def generate_story_fcpxml(markers, project_name="Interview", story_title="Story"
 
     timeline_dur_str = frames_to_fcpxml_time(offset_frames or media_frames, framerate)
 
+    asset_start_str = frames_to_fcpxml_time(start_tc_frames, framerate) if start_tc_frames else "0/1s"
+
     fcpxml = f"""<?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE fcpxml>
 
 <fcpxml version="1.11">
     <resources>
         <format id="r1" name="{_format_name(width, height, framerate)}" frameDuration="{frame_dur}" width="{width}" height="{height}" colorSpace="1-1-1 (Rec. 709)"/>
-        <asset id="r2" name="{_escape_xml(os.path.basename(source_path))}" start="0/1s" duration="{media_dur_str}" hasVideo="{1 if is_video else 0}" hasAudio="1" format="r1">
+        <asset id="r2" name="{_escape_xml(os.path.basename(source_path))}" start="{asset_start_str}" duration="{media_dur_str}" hasVideo="{1 if is_video else 0}" hasAudio="1" format="r1">
             <media-rep kind="original-media" src="{file_url}"/>
         </asset>
     </resources>

--- a/tests/test_fcpxml_timecode.py
+++ b/tests/test_fcpxml_timecode.py
@@ -1,0 +1,167 @@
+"""Embedded-timecode handling in FCPXML export.
+
+Root cause of a DJI import failure: cameras stamp time-of-day timecode, but Doza
+exported `asset start="0/1s"` with 0-based `asset-clip` starts. Final Cut keys an
+asset's source timecode off the media's real timecode, so every edit fell outside
+the asset's [start, start+duration] range and FCP rejected it with "Invalid edit
+with no respective media."
+
+The fix: read the media's embedded start timecode and express the asset `start`
+and every source-side clip/keyword `start` relative to it.
+"""
+
+import os
+import re
+import sys
+from fractions import Fraction
+
+import pytest
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from exporters.media_probe import timecode_to_frames, get_video_start_timecode_frames  # noqa: E402
+from fcpxml_export import generate_fcpxml, generate_story_fcpxml, seconds_to_frames  # noqa: E402
+
+
+def _rat(s):
+    s = s.strip().rstrip("s")
+    if "/" in s:
+        n, d = s.split("/")
+        return Fraction(int(n), int(d))
+    return Fraction(int(s))
+
+
+def _asset_start_dur(xml):
+    m = re.search(r'<asset id="r2"[^>]*start="([^"]+)"[^>]*duration="([^"]+)"', xml)
+    return _rat(m.group(1)), _rat(m.group(2))
+
+
+def _clips(xml):
+    out = []
+    for m in re.finditer(r"<asset-clip [^>]*?>", xml):
+        tag = m.group(0)
+        if 'ref="r2"' not in tag:
+            continue
+        out.append((
+            _rat(re.search(r' start="([^"]+)"', tag).group(1)),
+            _rat(re.search(r' duration="([^"]+)"', tag).group(1)),
+        ))
+    return out
+
+
+# ── timecode parsing ─────────────────────────────────────────────────
+
+class TestTimecodeToFrames:
+    def test_zero(self):
+        assert timecode_to_frames("00:00:00:00", 29.97) == 0
+
+    def test_one_hour_at_25(self):
+        assert timecode_to_frames("01:00:00:00", 25.0) == 3600 * 25
+
+    def test_dji_time_of_day_2997(self):
+        # 14:09:42:00 counted at the nominal 30 grid.
+        assert timecode_to_frames("14:09:42:00", 29.97) == (14 * 3600 + 9 * 60 + 42) * 30
+
+    def test_frames_field_2398(self):
+        assert timecode_to_frames("00:00:01:12", 23.976) == 24 + 12
+
+    def test_drop_frame_drops_two_per_minute(self):
+        # 00:01:00;02 — nominal 1802 minus the 2 dropped frames at minute one.
+        assert timecode_to_frames("00:01:00;02", 29.97) == 1800
+
+    def test_non_timecode_returns_none(self):
+        assert timecode_to_frames("not-a-tc", 29.97) is None
+        assert timecode_to_frames("1.5", 29.97) is None
+        assert timecode_to_frames("", 29.97) is None
+
+
+class TestStartTimecodeProbe:
+    def test_missing_file_returns_zero(self):
+        assert get_video_start_timecode_frames("/no/such/file.mp4", 29.97) == 0
+
+    def test_empty_path_returns_zero(self):
+        assert get_video_start_timecode_frames("", 29.97) == 0
+
+
+# ── export respects the embedded timecode ────────────────────────────
+
+@pytest.fixture
+def source(tmp_path):
+    p = tmp_path / "DJI_20260410140942_0017_D.mp4"
+    p.write_bytes(b"\x00")
+    return str(p)
+
+
+def test_zero_tc_keeps_legacy_asset_start(source):
+    xml = generate_fcpxml(
+        [{"start": 1.0, "end": 5.0, "text": "a", "category": "x"}],
+        "T", framerate=29.97, source_path=source, media_duration=60.0,
+        mode="cuts", start_tc_frames=0,
+    )
+    start, _ = _asset_start_dur(xml)
+    assert start == 0  # asset start="0/1s"
+
+
+def test_asset_start_equals_embedded_tc(source):
+    tc = timecode_to_frames("14:09:42:00", 29.97)  # 1,529,460 frames
+    xml = generate_fcpxml(
+        [{"start": 1.0, "end": 5.0, "text": "a", "category": "x"}],
+        "T", framerate=29.97, source_path=source, media_duration=60.0,
+        mode="cuts", start_tc_frames=tc,
+    )
+    start, _ = _asset_start_dur(xml)
+    # asset.start (seconds) == tc frames * frameDuration (1001/30000)
+    assert start == Fraction(tc * 1001, 30000)
+
+
+def test_every_clip_within_asset_timecode_range(source):
+    """Reconstructs the reported DJI clip (29.97, time-of-day TC). Every
+    asset-clip start must be >= asset.start and end <= asset.start+duration."""
+    tc = timecode_to_frames("14:09:42:00", 29.97)
+    markers = [
+        {"start": 13.01, "end": 19.99, "text": "purple", "category": "purple"},
+        {"start": 56.0,  "end": 59.0,  "text": "purple", "category": "purple"},
+        {"start": 111.0, "end": 114.0, "text": "purple", "category": "purple"},
+        {"start": 151.0, "end": 154.0, "text": "purple", "category": "purple"},
+        {"start": 165.0, "end": 171.0, "text": "purple", "category": "purple"},
+        {"start": 171.0, "end": 173.0, "text": "purple", "category": "purple"},
+    ]
+    xml = generate_fcpxml(markers, "DJI", framerate=29.97, source_path=source,
+                          media_duration=177.74, mode="cuts", start_tc_frames=tc)
+    a_start, a_dur = _asset_start_dur(xml)
+    a_end = a_start + a_dur
+    clips = _clips(xml)
+    assert len(clips) == 6
+    fd = Fraction(1001, 30000)
+    for s, d in clips:
+        assert s >= a_start, f"clip start {s} before asset start {a_start}"
+        assert s + d <= a_end, f"clip end {s + d} past asset end {a_end}"
+        assert (s / fd).denominator == 1  # frame-aligned
+
+
+def test_clip_start_is_tc_plus_inpoint(source):
+    tc = timecode_to_frames("10:00:00:00", 30.0)
+    xml = generate_fcpxml(
+        [{"start": 2.0, "end": 6.0, "text": "a", "category": "x"}],
+        "T", framerate=30.0, source_path=source, media_duration=60.0,
+        mode="cuts", start_tc_frames=tc,
+    )
+    a_start, _ = _asset_start_dur(xml)
+    clip_start = _clips(xml)[0][0]
+    inpoint_frames = seconds_to_frames(2.0, 30.0)  # 60
+    # clip source start = asset start + in-point
+    assert clip_start - a_start == Fraction(inpoint_frames, 30)
+
+
+def test_story_export_also_offsets_by_tc(source):
+    tc = timecode_to_frames("08:30:00:00", 25.0)
+    xml = generate_story_fcpxml(
+        [{"start": 5.0, "end": 10.0, "text": "beat", "_order": 0}],
+        "T", story_title="S", framerate=25.0, source_path=source,
+        media_duration=120.0, start_tc_frames=tc,
+    )
+    a_start, a_dur = _asset_start_dur(xml)
+    assert a_start == Fraction(tc, 25)
+    s, d = _clips(xml)[0]
+    assert s >= a_start
+    assert s + d <= a_start + a_dur


### PR DESCRIPTION
## Summary

Follow-up to #34 / v3.5.6. A user on DJI footage reported the **same** "Invalid edit with no respective media" error *after* updating. Their exported FCPXML (29.97, 4K) was structurally clean and frame-aligned — so 3.5.6's grid fix was working — but the asset still declared `start="0/1s"`.

## Root cause

Per the FCPXML spec, an `<asset>`'s `start` is its **source timecode**, and every `<asset-clip start>` must fall within `[asset.start, asset.start+duration]`. DJI/Sony cameras stamp **time-of-day timecode** (the user's clip: `2026-04-10 14:09:42`). Doza hard-coded `start="0/1s"` with 0-based clip starts, so when FCP resolved the real media (TC ≈ 14:09:42), every edit landed outside the asset's timecode range → rejected. This also explains why importing into a project that *already had* the media failed.

## Fix

- `exporters/media_probe.py`: `get_video_start_timecode_frames()` reads the `timecode` tag (format or `tmcd` stream) via ffprobe; `timecode_to_frames()` parses `HH:MM:SS:FF` (+ `;` drop-frame) to a whole-frame count.
- `fcpxml_export.py`: both generators take `start_tc_frames`; `asset.start = TC` and every source-side `start` (asset-clip + keyword + chapter-marker) = `TC + in-point`. Timeline offsets stay 0-based. **TC=0 media is byte-identical to before** — non-timecoded footage is unaffected.
- Threaded `start_tc_frames` through the exporter interface and probed it at both `app.py` export routes. (Premiere/EDL accept the kwarg for parity; source-TC handling there is a follow-up.)

## Tests

`tests/test_fcpxml_timecode.py` — timecode parsing (NDF/DF/invalid), `asset.start == embedded TC`, every clip within the asset's TC range, story export, and TC=0 back-compat. 182 FCPXML/exporter tests pass.

Version → **3.5.7**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
