### PR TITLE
fix: make non-English (German) transcription install flow actually reachable (#36)

### DIFF
--- a/app.py
+++ b/app.py
@@ -1394,13 +1394,22 @@ def serve_media_audio(project_id):
 
 
 # ── Optional non-English (Whisper) engine, installed on demand ─────────────
-# Default install ships only Parakeet MLX (English). Whisper is the gateway
-# to 99-language support but adds ~200MB of PyTorch+cmake to setup, so it's
-# moved behind this on-demand install. The Retranscribe modal calls these
-# endpoints when the user picks a non-English language and Whisper is missing.
+# Default install ships only Parakeet MLX (English). Whisper is the gateway to
+# 99-language support. Pulling it in on demand keeps the base setup small, but
+# the real cost is bigger than it looks: `pip install openai-whisper` drags in
+# PyTorch and friends (~500 MB), and the first non-English transcription then
+# downloads the large-v3-turbo speech model (~1.5 GB) on top. We do BOTH here,
+# with live streamed progress, so "Install non-English support" genuinely means
+# ready-to-go and the first German transcription doesn't stall on a silent
+# multi-GB download behind a fake progress bar (issue #36).
 
 import importlib.util as _impu
 import sys as _sys
+
+# The speech model _transcribe_whisper loads first (transcribe.py). Pre-fetching
+# this during install — instead of lazily mid-transcription — is what turns a
+# silent "hang" into visible progress.
+_WHISPER_MODEL = 'turbo'
 
 _whisper_install_state = {
     'status': 'idle',  # idle | running | done | error
@@ -1419,9 +1428,81 @@ def _engine_available(name):
         return False
 
 
+def _whisper_cache_dir():
+    """Where whisper.load_model caches weights (mirrors whisper's own default)."""
+    base = os.environ.get('XDG_CACHE_HOME') or os.path.join(os.path.expanduser('~'), '.cache')
+    return os.path.join(base, 'whisper')
+
+
+def _whisper_model_cached():
+    """True if the turbo weights are already on disk, so a re-run / second
+    project can skip the ~1.5 GB download."""
+    try:
+        return any(
+            f.startswith('large-v3-turbo') and f.endswith('.pt')
+            for f in os.listdir(_whisper_cache_dir())
+        )
+    except OSError:
+        return False
+
+
+def _whisper_ready():
+    """Non-English is truly ready only when BOTH the package is importable and
+    its speech model is downloaded. The frontend polls on this so 'done' means
+    the next transcription runs immediately rather than kicking off a hidden
+    multi-GB model download."""
+    return _engine_available('whisper') and _whisper_model_cached()
+
+
+def _stream_subprocess(cmd, set_detail, prefix='', timeout=3600):
+    """Run cmd, streaming combined stdout/stderr, pushing the freshest progress
+    line into the install banner via set_detail(). Handles tqdm's \\r-rewritten
+    progress bars (the model download) as well as pip's newline output. A
+    watchdog kills the process after `timeout` s so a stalled network can't wedge
+    the worker forever. Returns (returncode, tail) — tail is the last ~25 lines
+    for error reporting."""
+    import collections
+    import re as _re
+    proc = subprocess.Popen(
+        cmd, stdout=subprocess.PIPE, stderr=subprocess.STDOUT,
+        text=True, bufsize=1,
+        cwd=os.path.dirname(os.path.abspath(__file__)),
+    )
+    killer = threading.Timer(timeout, proc.kill)
+    killer.start()
+    tail = collections.deque(maxlen=25)
+    buf = ''
+    try:
+        assert proc.stdout is not None
+        while True:
+            chunk = proc.stdout.read(128)
+            if not chunk:
+                break
+            buf += chunk
+            # tqdm rewrites the current line with '\r'; pip uses '\n'. Split on
+            # both so we always surface the latest progress fragment.
+            parts = _re.split(r'[\r\n]', buf)
+            buf = parts.pop()
+            for line in parts:
+                line = line.strip()
+                if line:
+                    tail.append(line)
+                    set_detail(prefix + line)
+        if buf.strip():
+            tail.append(buf.strip())
+            set_detail(prefix + buf.strip())
+        proc.wait()
+    finally:
+        killer.cancel()
+    return proc.returncode, '\n'.join(tail)
+
+
 def _install_whisper_worker():
-    """Background install of openai-whisper into the running venv. Updates
-    _whisper_install_state so the frontend can poll for progress."""
+    """Background, on-demand prep of non-English support into the running venv:
+    pip-install openai-whisper (if missing), then pre-download the turbo speech
+    model (if missing). Both steps stream live progress into
+    _whisper_install_state so the banner shows real movement instead of a static
+    'this takes a few minutes' string (issue #36)."""
     global _whisper_install_state
 
     def set_state(status, detail):
@@ -1429,70 +1510,78 @@ def _install_whisper_worker():
             _whisper_install_state['status'] = status
             _whisper_install_state['detail'] = detail
 
+    def set_detail(detail):
+        with _whisper_install_lock:
+            _whisper_install_state['detail'] = detail
+
     try:
-        # cmake is a transitive build-time dep of some whisper sub-packages on
-        # certain Python versions. Best-effort install — if brew isn't present
-        # or the install fails, pip will tell us when it actually needs cmake.
-        set_state('running', 'Installing cmake (build dependency)...')
-        for brew_path in ('/opt/homebrew/bin/brew', '/usr/local/bin/brew'):
-            if os.path.isfile(brew_path):
-                subprocess.run(
-                    [brew_path, 'install', 'cmake'],
-                    capture_output=True, timeout=600,
-                )
-                break
+        # Step 1 — the package (+ PyTorch). All deps ship as binary wheels on the
+        # Python versions we support, so there's no source build and no cmake;
+        # the old proactive `brew install cmake` was pure latency with no UI
+        # feedback, so it's gone. pip installs into THIS venv because
+        # sys.executable is the venv python (launcher.sh sources the venv first).
+        if not _engine_available('whisper'):
+            set_state('running', 'Downloading the Whisper engine (~500 MB, includes PyTorch)…')
+            rc, tail = _stream_subprocess(
+                [_sys.executable, '-m', 'pip', 'install', '--progress-bar', 'on', 'openai-whisper'],
+                set_detail, prefix='pip · ',
+            )
+            if rc != 0:
+                set_state('error', f'Engine install failed: …{tail[-400:]}')
+                return
+            import importlib
+            importlib.invalidate_caches()
+            if not _engine_available('whisper'):
+                set_state('error', 'Install completed but the whisper module is not importable.')
+                return
 
-        # pip install into the same venv this Flask process is running from.
-        # sys.executable resolves to venv/bin/python3 because launcher.sh
-        # sources the venv before exec'ing app.py.
-        set_state('running', 'Installing OpenAI Whisper (~200MB) — this takes a few minutes...')
-        proc = subprocess.run(
-            [_sys.executable, '-m', 'pip', 'install', 'openai-whisper'],
-            capture_output=True, text=True, timeout=1800,
-        )
-        if proc.returncode != 0:
-            tail = (proc.stderr or proc.stdout or '')[-400:]
-            set_state('error', f'pip install failed: {tail}')
-            return
+        # Step 2 — the speech model (the big one). Done here, with progress, so
+        # the first German transcription is instant instead of stalling on a
+        # silent ~1.5 GB download.
+        if not _whisper_model_cached():
+            set_state('running', 'Downloading the speech model (~1.5 GB, one time)…')
+            rc, tail = _stream_subprocess(
+                # import transcribe first so its certifi SSL patch is applied —
+                # the weights are fetched over HTTPS and macOS framework Python
+                # otherwise fails certificate verification.
+                [_sys.executable, '-c',
+                 f'import transcribe, whisper; whisper.load_model("{_WHISPER_MODEL}")'],
+                set_detail, prefix='model · ',
+            )
+            if rc != 0 or not _whisper_model_cached():
+                set_state('error', f'Speech-model download failed: …{tail[-400:]}')
+                return
 
-        # Force a re-scan of the import system so transcribe.py picks up the
-        # new package without restarting Flask.
-        import importlib
-        importlib.invalidate_caches()
+        set_state('done', 'Done — non-English transcription is ready.')
 
-        if _engine_available('whisper'):
-            set_state('done', 'Done — non-English transcription is now available.')
-        else:
-            set_state('error', 'Install completed but whisper module is not importable.')
-
-    except subprocess.TimeoutExpired:
-        set_state('error', 'Install timed out after 30 minutes. Check your internet connection.')
     except Exception as e:
         set_state('error', f'Install failed: {e}')
 
 
 @app.route('/api/transcription-engines', methods=['GET'])
 def transcription_engines():
-    """Report which transcription engines are currently installed."""
+    """Report which transcription engines are ready to use. 'whisper' means
+    fully ready (package + speech model) so the install banner doesn't hide
+    itself while the ~1.5 GB model is still missing."""
     return jsonify({
         'parakeet': _engine_available('parakeet_mlx'),
-        'whisper': _engine_available('whisper'),
+        'whisper': _whisper_ready(),
     })
 
 
 @app.route('/api/install-whisper', methods=['POST'])
 def install_whisper():
-    """Kick off a background install of openai-whisper. Idempotent — returns
-    immediately if already installed or already running."""
+    """Kick off a background install of openai-whisper + speech model. Idempotent
+    — returns immediately if already fully ready or already running."""
     with _whisper_install_lock:
-        if _engine_available('whisper'):
+        if _whisper_ready():
             _whisper_install_state['status'] = 'done'
             _whisper_install_state['detail'] = 'Already installed.'
             return jsonify({'status': 'done'})
         if _whisper_install_state['status'] == 'running':
             return jsonify({'status': 'running'})
         _whisper_install_state['status'] = 'running'
-        _whisper_install_state['detail'] = 'Starting install...'
+        _whisper_install_state['detail'] = 'Starting…'
         _whisper_install_state['started_at'] = time.time()
 
     threading.Thread(target=_install_whisper_worker, daemon=True).start()
@@ -1504,7 +1593,7 @@ def install_whisper_status():
     """Poll endpoint for the frontend install banner."""
     with _whisper_install_lock:
         state = dict(_whisper_install_state)
-    state['available'] = _engine_available('whisper')
+    state['available'] = _whisper_ready()
     return jsonify(state)
 
 
@@ -1525,9 +1614,22 @@ def transcribe(project_id):
     # with a generic "no engine" error after the audio extraction. The frontend
     # uses needs_whisper_install to render an inline install prompt.
     requested_language = project.get('language', 'en')
-    if requested_language not in ('en', 'auto') and not _engine_available('whisper'):
-        project['status'] = 'error'
-        project['error'] = 'whisper_not_installed'
+    # 'auto' is NOT English-safe: transcribe.py skips Parakeet for anything that
+    # isn't literally 'en' and routes to Whisper, so Auto-detect needs the engine
+    # exactly like German does. The old guard whitelisted 'auto', so picking
+    # Auto-detect on a fresh install sailed past here and then hard-crashed
+    # downstream with a bare "No transcription engine found" 500 and no installer
+    # (issue #36). Treat every non-'en' language the same.
+    if requested_language != 'en' and not _engine_available('whisper'):
+        # Do NOT persist status='error' here. The transcribe card — which holds
+        # the on-demand installer banner and auto-retry — only renders while
+        # status == 'uploaded'. Flipping to 'error' hid that whole card on the
+        # next page load, so the install button the user was told about
+        # disappeared after a single attempt and left them dead-ended (issue
+        # #36). Keep the project in its pre-transcribe state so the banner
+        # reliably reappears on every visit until Whisper is installed.
+        project['status'] = 'uploaded'
+        project.pop('error', None)
         save_project(project_id, project)
         return jsonify({
             'error': f'Non-English transcription ({requested_language}) requires the Whisper engine, which is not installed.',
@@ -1587,6 +1689,21 @@ def transcribe(project_id):
         return jsonify({'status': 'transcribed', 'transcript': result})
 
     except Exception as e:
+        # Defense in depth for the guard above: if transcription still blew up
+        # on a non-English job because the Whisper engine isn't importable
+        # (e.g. it was uninstalled between the guard check and load_model, or a
+        # routing change slips a non-'en' job past the guard), surface the
+        # installer instead of a dead-end 500 — and keep the project renderable
+        # so the banner survives a reload (issue #36).
+        if requested_language != 'en' and not _engine_available('whisper'):
+            project['status'] = 'uploaded'
+            project.pop('error', None)
+            save_project(project_id, project)
+            return jsonify({
+                'error': f'Non-English transcription ({requested_language}) requires the Whisper engine, which is not installed.',
+                'needs_whisper_install': True,
+                'requested_language': requested_language,
+            }), 400
         project['status'] = 'error'
         project['error'] = str(e)
         save_project(project_id, project)

--- a/doza_assist/__init__.py
+++ b/doza_assist/__init__.py
@@ -1,3 +1,3 @@
 """Doza Assist core package."""
 
-__version__ = "3.5.8"
+__version__ = "3.5.9"

--- a/templates/dashboard.html
+++ b/templates/dashboard.html
@@ -213,7 +213,7 @@ window.addEventListener('DOMContentLoaded', refreshActivePill);
                             <option value="vi">Vietnamese</option>
                         </select>
                         <p id="languageHint" style="display:none; font-size: 0.75rem; color: var(--text-muted); margin-top: 0.5rem;">
-                            Non-English uses the Whisper engine. If it isn't installed yet, you'll be prompted to add it (~200&nbsp;MB, one time) when transcription starts.
+                            Non-English uses the Whisper engine. If it isn't installed yet, you'll be prompted to add it the first time you transcribe — a one-time ~2&nbsp;GB download (engine + speech model) with live progress.
                         </p>
                     </div>
                 </div>

--- a/templates/project.html
+++ b/templates/project.html
@@ -2685,7 +2685,7 @@ async function startTranscription() {
                 banner.innerHTML = `
                     <div style="color: var(--text-secondary); margin-bottom: 0.6rem;">
                         <strong style="color: var(--text-primary);">Whisper engine required.</strong><br>
-                        Transcribing non-English audio${lang ? ` (${lang})` : ''} uses the Whisper engine, which isn't installed yet — about 200&nbsp;MB, 5–10 minutes on a typical connection. It installs once.
+                        Transcribing non-English audio${lang ? ` (${lang})` : ''} uses the Whisper engine, which isn't installed yet. It downloads the engine and a speech model (~2&nbsp;GB total) one time — you'll see live progress below, and it can take 10–20&nbsp;minutes on a slower connection.
                     </div>
                     <button class="btn btn-sm btn-purple" id="firstRunInstallWhisper">Install non-English support</button>
                 `;
@@ -3341,7 +3341,7 @@ function updateWhisperBanner() {
     banner.innerHTML = `
         <div style="color: var(--text-secondary); margin-bottom: 0.5rem;">
             <strong style="color: var(--text-primary);">Non-English requires the Whisper engine.</strong><br>
-            Not installed yet — about 200&nbsp;MB, 5–10 minutes on a typical connection.
+            Not installed yet — downloads the engine and a speech model (~2&nbsp;GB total) one time, with live progress. Allow 10–20&nbsp;minutes on a slower connection.
         </div>
         <button class="btn btn-sm btn-purple" id="installWhisperBtn">
             Install non-English support

--- a/tests/test_whisper_install_guard.py
+++ b/tests/test_whisper_install_guard.py
@@ -1,0 +1,150 @@
+"""Regression tests for the on-demand Whisper installer flow (issue #36).
+
+The original v3.5.8 fix surfaced an install button, but a fresh user still
+dead-ended because:
+  * picking "Auto-detect" ('auto') bypassed the guard and crashed downstream
+    with a bare 500 and no installer; and
+  * the guard persisted status='error', which hid the only card that renders
+    the install button, so the affordance vanished after one attempt / reload.
+
+These tests pin the corrected contract: every non-English request without the
+engine returns a structured needs_whisper_install response AND leaves the
+project renderable (status='uploaded'), while English is unaffected.
+"""
+import os
+import sys
+import tempfile
+
+import pytest
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+import app as A  # noqa: E402
+import transcribe as T  # noqa: E402
+
+
+@pytest.fixture
+def src_file():
+    f = tempfile.NamedTemporaryFile(suffix='.wav', delete=False)
+    f.write(b'\x00' * 1024)
+    f.close()
+    yield f.name
+    os.unlink(f.name)
+
+
+@pytest.fixture
+def client(monkeypatch, src_file):
+    """A test client with whisper mocked MISSING and the project store stubbed.
+    Captures the persisted project so tests can assert on saved status."""
+    saved = {}
+    state = {'project': None}
+
+    monkeypatch.setattr(A, '_engine_available', lambda name: name == 'parakeet_mlx')
+    monkeypatch.setattr(A, 'get_project', lambda pid: state['project'])
+    monkeypatch.setattr(A, 'save_project', lambda pid, proj: saved.update(proj))
+
+    c = A.app.test_client()
+    c._saved = saved
+    c._src = src_file
+    c._state = state
+    return c
+
+
+def _project(client, language):
+    client._state['project'] = {
+        'id': 'p', 'name': 'n', 'status': 'uploaded', 'language': language,
+        'num_speakers': 2, 'source_path': client._src, 'filepath': client._src,
+        'interviewer_name': 'I', 'subject_name': 'S',
+    }
+
+
+@pytest.mark.parametrize('language', ['de', 'auto', 'fr', 'es'])
+def test_non_english_without_engine_offers_installer(client, language):
+    """Any non-English language (including 'auto') returns the structured
+    installer response instead of dead-ending."""
+    _project(client, language)
+    resp = client.post('/project/p/transcribe')
+    body = resp.get_json()
+    assert resp.status_code == 400
+    assert body['needs_whisper_install'] is True
+    assert body['requested_language'] == language
+
+
+@pytest.mark.parametrize('language', ['de', 'auto'])
+def test_guard_keeps_project_renderable(client, language):
+    """The guard must NOT persist status='error' — that hid the install card on
+    reload (the core #36 dead-end). Status stays 'uploaded'; error is cleared."""
+    _project(client, language)
+    client.post('/project/p/transcribe')
+    assert client._saved.get('status') == 'uploaded'
+    assert client._saved.get('error') in (None, '')
+
+
+def test_english_is_unaffected_by_guard(client, monkeypatch):
+    """English never needs Whisper; the guard must let it through to the normal
+    transcription path (mocked here so no model downloads)."""
+    _project(client, 'en')
+    monkeypatch.setattr(
+        T, 'transcribe_file',
+        lambda *a, **k: {'segments': [], 'language': 'en', 'engine': 'parakeet'})
+    resp = client.post('/project/p/transcribe')
+    body = resp.get_json()
+    assert resp.status_code == 200
+    assert not body.get('needs_whisper_install')
+
+
+def test_downstream_engine_loss_still_offers_installer(client, monkeypatch):
+    """Defense in depth: if a non-English job slips past the guard and fails in
+    transcribe_file because the engine is missing, the route still returns the
+    installer (not a raw 500) and keeps the project renderable."""
+    _project(client, 'de')
+    # Guard sees whisper present, so it passes; transcribe_file then fails as if
+    # the engine vanished (TOCTOU). Engine probe reports missing in the except.
+    calls = {'n': 0}
+
+    def flaky_available(name):
+        if name == 'parakeet_mlx':
+            return True
+        # whisper: present for the guard's first call, missing afterwards.
+        calls['n'] += 1
+        return calls['n'] == 1
+
+    monkeypatch.setattr(A, '_engine_available', flaky_available)
+    monkeypatch.setattr(T, 'transcribe_file', lambda *a, **k: (_ for _ in ()).throw(
+        RuntimeError('No transcription engine found.')))
+    resp = client.post('/project/p/transcribe')
+    body = resp.get_json()
+    assert resp.status_code == 400
+    assert body['needs_whisper_install'] is True
+    assert client._saved.get('status') == 'uploaded'
+
+
+def test_whisper_ready_requires_package_and_model(monkeypatch):
+    """_whisper_ready gates on BOTH the package and the cached model so the UI
+    doesn't report 'done' while the ~1.5GB model is still missing."""
+    monkeypatch.setattr(A, '_engine_available', lambda name: True)
+    monkeypatch.setattr(A, '_whisper_model_cached', lambda: False)
+    assert A._whisper_ready() is False
+    monkeypatch.setattr(A, '_whisper_model_cached', lambda: True)
+    assert A._whisper_ready() is True
+
+
+def test_stream_subprocess_captures_progress_and_returncode():
+    """The installer streams live progress: tqdm-style \\r frames and \\n lines
+    are both surfaced, and the child's exit code is returned."""
+    details = []
+    prog = (
+        'import sys\n'
+        'for p in (10, 55, 100):\n'
+        '    sys.stdout.write(f"\\r {p}/100")\n'
+        '    sys.stdout.flush()\n'
+        'sys.stdout.write("\\nfinished\\n")\n'
+    )
+    rc, tail = A._stream_subprocess([sys.executable, '-c', prog], details.append)
+    assert rc == 0
+    assert details, 'expected streamed progress frames'
+    assert 'finished' in tail
+    assert '100/100' in tail
+
+    rc2, _ = A._stream_subprocess([sys.executable, '-c', 'import sys; sys.exit(7)'],
+                                  details.append)
+    assert rc2 == 7


### PR DESCRIPTION
## Why

Issue #36 ("Needs Whisper for German transcription") was reported fixed in v3.5.8, but the fix didn't hold up. A diagnosis of the full non-English install→transcribe chain found the v3.5.8 installer button was effectively unreachable:

- **The button vanished after one render.** The transcribe guard persisted `status='error'`, but the card that hosts the installer (and the auto-retry) only renders while `status=='uploaded'`. So the moment the page reloaded, the user was left with no install affordance and no Retranscribe menu — the exact "can't find where to install Whisper" dead-end from the issue.
- **Auto-detect was worse.** The guard whitelisted `'auto'`, so picking "Auto-detect" sailed past the guard and crashed downstream with a bare 500 and *no* installer at all.
- **The install "looked broken."** "~200 MB" was wildly off (real cost ~2 GB: PyTorch engine + a 1.5 GB speech model), there was zero progress streaming, and the 1.5 GB model downloaded *silently* during the first transcription behind a fake 30-second progress bar — indistinguishable from a hang.

## What changed

- **Guard** treats every non-`en` language (including `auto`) the same and keeps `status='uploaded'`, so the install banner reliably reappears on every visit until Whisper is installed.
- **Downstream catch-all** also surfaces the installer (TOCTOU defense) instead of a raw 500.
- **Installer is honest and observable:** streams live pip + model-download progress, drops the dead `brew install cmake` step, and pre-fetches the ~1.5 GB `turbo` speech model *during* install — so the first German transcription is instant, not a silent multi-GB hang. Readiness now means package **and** model present.
- **Copy fixed:** "~200 MB" → realistic ~2 GB (engine + model), one time, with live progress.
- **Regression tests** pin the guard / installer contract (`tests/test_whisper_install_guard.py`).

## Testing

- New `tests/test_whisper_install_guard.py`: 10 passing — covers `de`/`auto`/`fr`/`es` surfacing the installer, status staying renderable, English unaffected, the downstream TOCTOU path, `_whisper_ready` gating on package+model, and the progress streamer.
- Verified the rewritten worker's helpers, streaming (`\r` tqdm + `\n`), endpoint idempotency, and the exact model-prefetch subprocess against the live venv.
- Full suite: no new failures (pre-existing chat/DNA failures are unrelated and present on `main`).

Closes #36.

🤖 Generated with [Claude Code](https://claude.com/claude-code)