### PR TITLE
fix: v3.5.10 — engine fallback installer (#39), German AI-analysis, install heartbeat

### DIFF
--- a/ai_analysis.py
+++ b/ai_analysis.py
@@ -3861,6 +3861,13 @@ def _cap_and_rank_analysis(accum, segment_vectors=None, cap=7):
         deduped = []
         for b in out['broll_suggestions']:
             if isinstance(b, dict):
+                # Drop timecode-less entries. A salvaged trailing element from a
+                # truncated reply (the JSON-repair path) can be an empty {} or a
+                # description with no start/end — it can't be placed on a
+                # timeline, and unlike clips/soundbites b-roll has no later
+                # timecode filter, so skip it here.
+                if not (b.get('start') or b.get('end')):
+                    continue
                 key = json.dumps({k: b.get(k) for k in sorted(b.keys())}, sort_keys=True)
             else:
                 key = str(b).strip().lower()
@@ -5037,67 +5044,108 @@ def _parse_json_response(response_text):
 
 
 def _repair_truncated_json(text):
-    """Attempt to repair truncated JSON by closing open structures."""
-    # Strip trailing whitespace
-    text = text.rstrip()
+    """Repair truncated JSON by rewinding to the last fully-formed element of the
+    deepest still-open container, then closing the remaining open structures.
 
-    # If we're mid-string, close it: find if we have unmatched quote
+    Ollama (``/api/generate`` with ``format='json'``) stops mid-object when its
+    output runs past ``num_predict`` (``done_reason='length'``). The previous
+    implementation only closed open braces at the raw cut point, which left a
+    dangling key/value behind and produced structurally-invalid JSON — so a
+    response whose *leading* items were complete got discarded whole, the parse
+    fell through to the error dict, and the analysis came back empty (the German /
+    long-interview "Analysis produced no results" report). Verbose languages hit
+    this constantly because they spend ~40-50% more tokens on the same verbatim
+    quotes.
+
+    This version keeps every complete element and drops only the half-written
+    trailing one. It forward-scans with a container stack where each frame records
+    ``last_complete`` — the index just AFTER its last fully-formed element (or just
+    after the opening bracket if none yet). On truncation it rewinds the deepest
+    open frame to that boundary, strips trailing separators, and appends closers
+    innermost-first. Already-valid JSON is returned unchanged (idempotent)."""
+    text = text.rstrip()
+    if not text:
+        return text
+
+    stack = []          # frames: {'type': 'obj'|'arr', 'last_complete': int, 'expect_value': bool}
     in_str = False
     esc = False
-    last_quote = -1
+    scalar_start = -1   # index where the current bare scalar (number/true/false/null) began
+
+    def _finalize_scalar(end_idx):
+        # A bare scalar only ever appears as a VALUE; completing one advances the
+        # enclosing frame's last_complete and ends any object's value slot.
+        nonlocal scalar_start
+        if scalar_start != -1 and stack:
+            stack[-1]['last_complete'] = end_idx
+            if stack[-1]['type'] == 'obj':
+                stack[-1]['expect_value'] = False
+        scalar_start = -1
+
     for i, ch in enumerate(text):
-        if esc:
-            esc = False
+        if in_str:
+            if esc:
+                esc = False
+            elif ch == '\\':
+                esc = True
+            elif ch == '"':
+                in_str = False
+                # A closed string is a VALUE iff we're in an array, or in an
+                # object after a ':' — object KEYS must not advance last_complete,
+                # otherwise a dangling '"key":' would be kept as if complete.
+                if stack:
+                    fr = stack[-1]
+                    if fr['type'] == 'arr' or fr.get('expect_value'):
+                        fr['last_complete'] = i + 1
+                        if fr['type'] == 'obj':
+                            fr['expect_value'] = False
             continue
-        if ch == '\\' and in_str:
-            esc = True
-            continue
+
         if ch == '"':
-            in_str = not in_str
-            last_quote = i
+            _finalize_scalar(i)
+            in_str = True
+        elif ch in ' \t\r\n':
+            _finalize_scalar(i)
+        elif ch == '{' or ch == '[':
+            _finalize_scalar(i)
+            stack.append({
+                'type': 'obj' if ch == '{' else 'arr',
+                'last_complete': i + 1,
+                'expect_value': False,
+            })
+        elif ch == '}' or ch == ']':
+            _finalize_scalar(i)
+            if stack:
+                stack.pop()
+                if stack:  # a closed container is a completed value for its parent
+                    stack[-1]['last_complete'] = i + 1
+                    if stack[-1]['type'] == 'obj':
+                        stack[-1]['expect_value'] = False
+        elif ch == ':':
+            _finalize_scalar(i)
+            if stack and stack[-1]['type'] == 'obj':
+                stack[-1]['expect_value'] = True
+        elif ch == ',':
+            _finalize_scalar(i)
+            if stack and stack[-1]['type'] == 'obj':
+                stack[-1]['expect_value'] = False
+        elif scalar_start == -1:
+            scalar_start = i  # start of a bare scalar token
 
-    # If we're inside an open string, truncate to last clean point before it
-    if in_str and last_quote > 0:
-        # Close the string and trim any trailing partial value
-        text = text[:last_quote + 1]
-        # We may now have something like  "key": "value  — close quote
-        if not text.endswith('"'):
-            text += '"'
+    # Cleanly balanced and not mid-token → already valid JSON; leave it alone.
+    if not stack and not in_str and scalar_start == -1:
+        return text
+    if not stack:
+        # Balanced brackets but trailing junk at top level — nothing sensible to
+        # close. Hand it back unchanged; the caller's json.loads will reject it.
+        return text
 
-    # Remove trailing commas, colons, or partial tokens
-    text = text.rstrip()
-    while text and text[-1] in (',', ':', ' ', '\n', '\t'):
-        text = text[:-1]
+    # Rewind the deepest open frame past its half-written trailing element, drop
+    # any trailing separators, then close every open frame innermost-first.
+    repaired = text[:stack[-1]['last_complete']].rstrip()
+    while repaired and repaired[-1] in (',', ':', ' ', '\t', '\r', '\n'):
+        repaired = repaired[:-1].rstrip()
+    for fr in reversed(stack):
+        repaired += '}' if fr['type'] == 'obj' else ']'
 
-    # Count open braces/brackets and close them
-    open_braces = 0
-    open_brackets = 0
-    in_string = False
-    escape_next = False
-
-    for ch in text:
-        if escape_next:
-            escape_next = False
-            continue
-        if ch == '\\' and in_string:
-            escape_next = True
-            continue
-        if ch == '"' and not escape_next:
-            in_string = not in_string
-            continue
-        if in_string:
-            continue
-        if ch == '{':
-            open_braces += 1
-        elif ch == '}':
-            open_braces -= 1
-        elif ch == '[':
-            open_brackets += 1
-        elif ch == ']':
-            open_brackets -= 1
-
-    # Close any remaining open structures
-    text += ']' * max(0, open_brackets)
-    text += '}' * max(0, open_braces)
-
-    return text
+    return repaired

--- a/ai_providers/ollama_provider.py
+++ b/ai_providers/ollama_provider.py
@@ -81,11 +81,17 @@ class OllamaProvider(BaseProvider):
                     "keep_alive": _KEEP_ALIVE,
                     "options": {
                         "temperature": kwargs.get("temperature", 0.1),
-                        # Bumped from 768 → 4096. The story-analyze schema
-                        # easily needs 1k+ output tokens; 768 was forcing
-                        # format='json' to close the JSON early, producing
-                        # syntactically valid but mostly empty dicts.
-                        "num_predict": kwargs.get("num_predict", 4096),
+                        # Bumped 768 → 4096 → 8192. The story-analyze schema asks
+                        # for up to 7 items each carrying a VERBATIM transcript
+                        # quote; in a token-verbose language (German runs ~40-50%
+                        # longer than English for the same words) the JSON routinely
+                        # ran past 4096 output tokens, so format='json' returned
+                        # done_reason='length' with the object cut mid-element and
+                        # the analysis came back empty (the German "produced no
+                        # results" report). The three-pass split keeps each call's
+                        # schema small, so a higher ceiling rarely adds latency on
+                        # normal inputs but removes the truncation trigger.
+                        "num_predict": kwargs.get("num_predict", 8192),
                         # Bumped 12288 → 32768. Generous context window
                         # prevents transcript truncation on long interviews.
                         "num_ctx": kwargs.get("num_ctx", 32768),

--- a/app.py
+++ b/app.py
@@ -1434,14 +1434,31 @@ def _whisper_cache_dir():
     return os.path.join(base, 'whisper')
 
 
+# The healthy large-v3-turbo weights are ~1.62 GB. whisper writes the download
+# straight to the FINAL path with no temp-file + atomic rename, so a download
+# interrupted mid-write (watchdog kill, app quit, dropped network) leaves a
+# truncated .pt sitting at the real cache path. A filename-only check would then
+# report that corrupt partial as "ready" — _whisper_ready() goes True, the banner
+# hides, /api/install-whisper short-circuits to "done", and the next non-English
+# transcription silently re-downloads the full ~1.6 GB mid-run (issues #13, #36).
+# Gate on a conservative size floor so a partial is treated as not installed.
+_WHISPER_MODEL_MIN_BYTES = 1_500_000_000
+
+
 def _whisper_model_cached():
-    """True if the turbo weights are already on disk, so a re-run / second
-    project can skip the ~1.5 GB download."""
+    """True only if a FULL-SIZE turbo weight file is on disk, so a re-run /
+    second project can skip the ~1.6 GB download. A truncated partial left by an
+    interrupted download does not count."""
     try:
-        return any(
-            f.startswith('large-v3-turbo') and f.endswith('.pt')
-            for f in os.listdir(_whisper_cache_dir())
-        )
+        d = _whisper_cache_dir()
+        for f in os.listdir(d):
+            if f.startswith('large-v3-turbo') and f.endswith('.pt'):
+                try:
+                    if os.path.getsize(os.path.join(d, f)) >= _WHISPER_MODEL_MIN_BYTES:
+                        return True
+                except OSError:
+                    continue
+        return False
     except OSError:
         return False
 
@@ -1454,15 +1471,24 @@ def _whisper_ready():
     return _engine_available('whisper') and _whisper_model_cached()
 
 
-def _stream_subprocess(cmd, set_detail, prefix='', timeout=3600):
+def _stream_subprocess(cmd, set_detail, prefix='', timeout=3600, heartbeat_interval=5):
     """Run cmd, streaming combined stdout/stderr, pushing the freshest progress
     line into the install banner via set_detail(). Handles tqdm's \\r-rewritten
     progress bars (the model download) as well as pip's newline output. A
     watchdog kills the process after `timeout` s so a stalled network can't wedge
     the worker forever. Returns (returncode, tail) — tail is the last ~25 lines
-    for error reporting."""
+    for error reporting.
+
+    A background heartbeat refreshes the banner with elapsed time every few
+    seconds even when the child emits nothing newline-terminated for a long
+    stretch. pip piped to a non-TTY and the ~1.6 GB model download can both go
+    quiet for minutes inside the blocking read below; that previously left the
+    banner frozen on its last line, which read to users as "stuck on Starting
+    install…" (reddit report). The heartbeat runs independently of the read, so
+    the banner always shows movement while the worker is alive."""
     import collections
     import re as _re
+    import time as _time
     proc = subprocess.Popen(
         cmd, stdout=subprocess.PIPE, stderr=subprocess.STDOUT,
         text=True, bufsize=1,
@@ -1472,6 +1498,27 @@ def _stream_subprocess(cmd, set_detail, prefix='', timeout=3600):
     killer.start()
     tail = collections.deque(maxlen=25)
     buf = ''
+    start = _time.monotonic()
+    hb = {'last_line': '', 'last_emit': start}
+    hb_stop = threading.Event()
+
+    def _heartbeat():
+        # Every 5s, if no real progress line has surfaced recently, refresh the
+        # banner with the last line + a growing elapsed clock so it never looks
+        # frozen. Fires only while the child is alive (hb_stop gates the wait).
+        while not hb_stop.wait(heartbeat_interval):
+            if _time.monotonic() - hb['last_emit'] >= heartbeat_interval:
+                secs = int(_time.monotonic() - start)
+                base = hb['last_line'] or 'Working…'
+                set_detail(f"{prefix}{base} · {secs // 60}m {secs % 60:02d}s elapsed")
+
+    def _emit(line):
+        hb['last_line'] = line
+        hb['last_emit'] = _time.monotonic()
+        set_detail(prefix + line)
+
+    hb_thread = threading.Thread(target=_heartbeat, daemon=True)
+    hb_thread.start()
     try:
         assert proc.stdout is not None
         while True:
@@ -1487,12 +1534,13 @@ def _stream_subprocess(cmd, set_detail, prefix='', timeout=3600):
                 line = line.strip()
                 if line:
                     tail.append(line)
-                    set_detail(prefix + line)
+                    _emit(line)
         if buf.strip():
             tail.append(buf.strip())
-            set_detail(prefix + buf.strip())
+            _emit(buf.strip())
         proc.wait()
     finally:
+        hb_stop.set()
         killer.cancel()
     return proc.returncode, '\n'.join(tail)
 
@@ -1549,6 +1597,21 @@ def _install_whisper_worker():
                 set_detail, prefix='model · ',
             )
             if rc != 0 or not _whisper_model_cached():
+                # A watchdog kill / dropped network can leave a truncated
+                # large-v3-turbo.pt at the final path. Remove the partial so the
+                # next "Try again" runs a real download instead of the Step-2
+                # skip-check (above) seeing the file and reporting instant — but
+                # false — success on a corrupt model.
+                try:
+                    import glob as _glob
+                    for _p in _glob.glob(os.path.join(_whisper_cache_dir(), 'large-v3-turbo*.pt')):
+                        try:
+                            if os.path.getsize(_p) < _WHISPER_MODEL_MIN_BYTES:
+                                os.remove(_p)
+                        except OSError:
+                            pass
+                except Exception:
+                    pass
                 set_state('error', f'Speech-model download failed: …{tail[-400:]}')
                 return
 
@@ -1594,6 +1657,8 @@ def install_whisper_status():
     with _whisper_install_lock:
         state = dict(_whisper_install_state)
     state['available'] = _whisper_ready()
+    started = state.get('started_at')
+    state['elapsed'] = int(time.time() - started) if started else 0
     return jsonify(state)
 
 
@@ -1689,25 +1754,40 @@ def transcribe(project_id):
         return jsonify({'status': 'transcribed', 'transcript': result})
 
     except Exception as e:
-        # Defense in depth for the guard above: if transcription still blew up
-        # on a non-English job because the Whisper engine isn't importable
-        # (e.g. it was uninstalled between the guard check and load_model, or a
-        # routing change slips a non-'en' job past the guard), surface the
-        # installer instead of a dead-end 500 — and keep the project renderable
-        # so the banner survives a reload (issue #36).
-        if requested_language != 'en' and not _engine_available('whisper'):
+        # Surface the in-app Whisper installer instead of a dead-end 500 whenever
+        # a job ran out of transcription engines and Whisper isn't ready — and
+        # keep the project renderable (status='uploaded') so the install banner
+        # survives a reload. Two ways this fires:
+        #   * non-English jobs that slipped past the pre-flight guard (e.g. the
+        #     engine was uninstalled between the guard check and load_model), and
+        #   * ENGLISH jobs where Parakeet was tried first and crashed/failed on
+        #     the file (the issue #23 Metal-crash class hits certain MXF/AVC and
+        #     some mp4 inputs), then fell back to WhisperX/Whisper — which aren't
+        #     installed on a fresh DMG. That used to dead-end with a bare "No
+        #     transcription engine found … pip install" 500 and no installer
+        #     button, which the user can't act on from inside the app (issue #39).
+        # Whisper is the universal fallback engine, so offer it for ANY language
+        # once every engine is exhausted. Gate on _whisper_ready() (package AND
+        # speech model) so a half-installed engine still routes to the installer.
+        err_text = str(e)
+        no_engine = 'No transcription engine found' in err_text
+        if (requested_language != 'en' or no_engine) and not _whisper_ready():
             project['status'] = 'uploaded'
             project.pop('error', None)
             save_project(project_id, project)
             return jsonify({
-                'error': f'Non-English transcription ({requested_language}) requires the Whisper engine, which is not installed.',
+                'error': (
+                    'Transcription needs the Whisper engine, which is not installed.'
+                    if requested_language == 'en'
+                    else f'Non-English transcription ({requested_language}) requires the Whisper engine, which is not installed.'
+                ),
                 'needs_whisper_install': True,
                 'requested_language': requested_language,
             }), 400
         project['status'] = 'error'
-        project['error'] = str(e)
+        project['error'] = err_text
         save_project(project_id, project)
-        return jsonify({'error': str(e)}), 500
+        return jsonify({'error': err_text}), 500
 
 
 def _analyze_status_path(project_id):
@@ -1844,7 +1924,12 @@ def analyze(project_id):
         if not (result.get('story_beats') or result.get('social_clips')
                 or result.get('strongest_soundbites')):
             _clear_analyze_status(project_id)
-            return jsonify({'error': 'Analysis produced no results — the model may need to be restarted. Try again.'}), 500
+            # The old copy told users to restart the model, which never helped
+            # (the model is healthy — its JSON reply was getting cut off on long /
+            # verbose-language interviews and dropped during parse). Point at the
+            # real cause and an action that can actually work now that truncated
+            # replies are salvaged.
+            return jsonify({'error': "Analysis came back empty. This can happen on a very long or non-English interview when the model's reply gets cut off. Try again — and if it keeps happening, try a shorter section or a different analysis model."}), 500
         project['analysis'] = result
 
         analyzer_total = analyzer_state['total']

--- a/doza_assist/__init__.py
+++ b/doza_assist/__init__.py
@@ -1,3 +1,3 @@
 """Doza Assist core package."""
 
-__version__ = "3.5.9"
+__version__ = "3.5.10"

--- a/templates/project.html
+++ b/templates/project.html
@@ -2671,23 +2671,31 @@ async function startTranscription() {
             showToast('Transcription complete!');
             setTimeout(() => reloadAndKeepTab('transcript'), 3000);
         } else if (data.needs_whisper_install) {
-            // Non-English was requested but the Whisper engine isn't installed.
-            // Surface the same on-demand installer the Retranscribe modal uses,
-            // right here at the first wall the user hits, then auto-retry once
-            // the engine is ready (issue #36).
+            // The job needs the Whisper engine but it isn't installed. Fires for
+            // non-English jobs (Parakeet is English-only) AND for English jobs
+            // whose Parakeet engine crashed/failed on the file and fell back to
+            // Whisper, which isn't bundled (issues #36, #39). Surface the same
+            // on-demand installer the Retranscribe modal uses, right here at the
+            // first wall the user hits, then auto-retry once the engine is ready.
+            const reqLang = data.requested_language;
+            const isEn = !reqLang || reqLang === 'en';
+            const lang = (reqLang || '').toUpperCase();
             fill.style.width = '0%';
-            statusText.textContent = 'Non-English transcription needs an extra engine';
+            statusText.textContent = isEn
+                ? 'Transcription needs an extra engine'
+                : 'Non-English transcription needs an extra engine';
             timeText.textContent = '';
             const banner = document.getElementById('transcribeWhisperBanner');
             if (banner) {
-                const lang = (data.requested_language || '').toUpperCase();
                 banner.style.display = 'block';
                 banner.innerHTML = `
                     <div style="color: var(--text-secondary); margin-bottom: 0.6rem;">
                         <strong style="color: var(--text-primary);">Whisper engine required.</strong><br>
-                        Transcribing non-English audio${lang ? ` (${lang})` : ''} uses the Whisper engine, which isn't installed yet. It downloads the engine and a speech model (~2&nbsp;GB total) one time — you'll see live progress below, and it can take 10–20&nbsp;minutes on a slower connection.
+                        ${isEn
+                            ? `This file couldn't be handled by the fast engine and needs the Whisper engine as a fallback, which isn't installed yet.`
+                            : `Transcribing non-English audio${lang ? ` (${lang})` : ''} uses the Whisper engine, which isn't installed yet.`} It downloads the engine and a speech model (~2&nbsp;GB total) one time — you'll see live progress below, and it can take 10–20&nbsp;minutes on a slower connection.
                     </div>
-                    <button class="btn btn-sm btn-purple" id="firstRunInstallWhisper">Install non-English support</button>
+                    <button class="btn btn-sm btn-purple" id="firstRunInstallWhisper">Install transcription engine</button>
                 `;
                 const ib = document.getElementById('firstRunInstallWhisper');
                 if (ib) ib.onclick = () => runWhisperInstall(banner, () => {
@@ -3377,12 +3385,24 @@ async function runWhisperInstall(container, onDone) {
     }
 
     if (_whisperPollTimer) clearInterval(_whisperPollTimer);
+    let _pollFails = 0;
     _whisperPollTimer = setInterval(async () => {
         let state;
         try {
             const sres = await fetch('/api/install-whisper/status');
             state = await sres.json();
-        } catch (err) { return; }
+            _pollFails = 0;
+        } catch (err) {
+            // Don't silently freeze on a transient blip — but if the server is
+            // unreachable for several polls in a row, surface it instead of
+            // leaving the banner stuck on its last line forever.
+            if (++_pollFails > 5) {
+                clearInterval(_whisperPollTimer);
+                _whisperPollTimer = null;
+                container.innerHTML = '<div style="color: var(--danger, #f85149);">Lost contact with the server during install. Check that Doza Assist is still running, then try again.</div>';
+            }
+            return;
+        }
 
         if (state.status === 'done' || state.available) {
             clearInterval(_whisperPollTimer);
@@ -3402,9 +3422,12 @@ async function runWhisperInstall(container, onDone) {
             const retry = document.getElementById('retryWhisperBtn');
             if (retry) retry.onclick = () => runWhisperInstall(container, onDone);
         } else {
+            const elapsed = state.elapsed
+                ? ` · ${Math.floor(state.elapsed / 60)}m ${state.elapsed % 60}s elapsed`
+                : '';
             container.innerHTML = `
                 <div style="color: var(--text-secondary);">
-                    ${(state.detail || 'Installing…').replace(/</g, '&lt;')}
+                    ${(state.detail || 'Installing…').replace(/</g, '&lt;')}${elapsed}
                 </div>
             `;
         }

--- a/tests/test_json_repair.py
+++ b/tests/test_json_repair.py
@@ -1,0 +1,93 @@
+"""Regression tests for _repair_truncated_json (the AI-analysis empty-results bug).
+
+Ollama (/api/generate, format='json') stops mid-object when its reply runs past
+num_predict (done_reason='length'). Token-verbose languages like German hit this
+constantly. The old repair only closed open braces at the raw cut point, leaving a
+dangling key/value -> structurally invalid JSON -> the whole reply (including its
+complete leading items) was discarded -> "Analysis produced no results".
+
+The rewrite rewinds to the last fully-formed element of the deepest still-open
+container and closes the rest, so every COMPLETE item survives and only the
+half-written trailing one is dropped. These tests pin that contract.
+"""
+import json
+import os
+import sys
+
+import pytest
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+from ai_analysis import _repair_truncated_json as repair  # noqa: E402
+from ai_analysis import _parse_json_response  # noqa: E402
+
+
+# Each case: a truncated buffer, and the count of complete soundbite objects that
+# MUST survive (verbatim, with their data intact).
+_SOUNDBITE_TRUNCATIONS = [
+    # cut on a dangling key (no colon yet)
+    ('{"strongest_soundbites": [{"text": "a", "start": "1"}, '
+     '{"text": "b", "start": "2"}, {"text"', 2),
+    # cut mid-string value
+    ('{"strongest_soundbites": [{"text": "a", "start": "1"}, {"text": "hello wor', 1),
+    # cut right after a key + colon
+    ('{"strongest_soundbites": [{"text": "a", "start": "1"}, {"text":', 1),
+    # cut mid-key
+    ('{"strongest_soundbites": [{"text": "a", "start": "1"}, {"te', 1),
+    # cut mid-scalar value
+    ('{"items": [{"rank": 1}, {"rank": 2', 1),
+]
+
+
+@pytest.mark.parametrize('raw,survivors', _SOUNDBITE_TRUNCATIONS)
+def test_truncations_parse_and_keep_complete_items(raw, survivors):
+    repaired = repair(raw)
+    obj = json.loads(repaired)  # must be valid JSON now
+    # the list lives under whichever single key the object has
+    (arr,) = list(obj.values())
+    complete = [el for el in arr if isinstance(el, dict) and el]  # drop salvaged {}
+    assert len(complete) == survivors
+
+
+def test_nested_arrays_preserved():
+    """A clip carrying a nested tags array survives whole; the dangling tail dies."""
+    raw = '{"clips": [{"tags": ["x", "y"], "start": "1"}], "extra'
+    obj = json.loads(repair(raw))
+    assert obj['clips'] == [{'tags': ['x', 'y'], 'start': '1'}]
+
+
+def test_truncated_inside_nested_array():
+    raw = '{"clips": [{"tags": ["x", "y'
+    obj = json.loads(repair(raw))
+    # the half-written clip collapses to {} (dropped downstream); valid JSON either way
+    assert isinstance(obj['clips'], list)
+
+
+@pytest.mark.parametrize('valid', [
+    '{"a": [1, 2, {"b": 3}]}',
+    '{"clips": [{"tags": ["x", "y"], "start": "1"}]}',
+    '{"strongest_soundbites": []}',
+    '{}',
+])
+def test_already_valid_json_is_untouched(valid):
+    """Idempotent: complete JSON must be returned byte-identical (it never reaches
+    repair in practice, but the safety net must not corrupt it)."""
+    assert repair(valid) == valid
+    json.loads(repair(valid))
+
+
+def test_just_opening_brace():
+    assert json.loads(repair('{')) == {}
+
+
+def test_parse_json_response_recovers_truncated_soundbites():
+    """End-to-end through the real parser: a truncated reply that the OLD repair
+    threw away now yields the recovered list key (not the error fallback dict)."""
+    truncated = ('{"strongest_soundbites": [{"text": "real quote one", '
+                 '"start": "00:01:00", "end": "00:01:10", "why": "thesis"}, '
+                 '{"text": "second quote but cut off here mid')
+    parsed = _parse_json_response(truncated)
+    assert 'strongest_soundbites' in parsed
+    complete = [s for s in parsed['strongest_soundbites'] if s]
+    assert len(complete) == 1
+    assert complete[0]['text'] == 'real quote one'
+    assert 'error' not in parsed

--- a/tests/test_whisper_install_guard.py
+++ b/tests/test_whisper_install_guard.py
@@ -118,6 +118,76 @@ def test_downstream_engine_loss_still_offers_installer(client, monkeypatch):
     assert client._saved.get('status') == 'uploaded'
 
 
+def test_english_no_engine_offers_installer(client, monkeypatch):
+    """Issue #39: an English job tries Parakeet first; when it crashes/fails on a
+    file (the issue #23 Metal-crash class) it falls back to Whisper, which isn't
+    installed on a fresh DMG, and transcribe_file raises 'No transcription engine
+    found'. The route must offer the SAME in-app installer (not a bare pip-install
+    500) and keep the project renderable so the banner survives a reload."""
+    _project(client, 'en')
+    # whisper absent (fixture: _engine_available True only for parakeet_mlx), so
+    # _whisper_ready() is False. transcribe_file exhausts every engine.
+    monkeypatch.setattr(T, 'transcribe_file', lambda *a, **k: (_ for _ in ()).throw(
+        RuntimeError('No transcription engine found. Install one of: ...')))
+    resp = client.post('/project/p/transcribe')
+    body = resp.get_json()
+    assert resp.status_code == 400
+    assert body['needs_whisper_install'] is True
+    assert body['requested_language'] == 'en'
+    assert client._saved.get('status') == 'uploaded'
+    assert client._saved.get('error') in (None, '')
+
+
+def test_english_non_engine_error_still_500s(client, monkeypatch):
+    """The English fallback must fire ONLY for the no-engine exhaustion case. A
+    different failure (e.g. an undecodable/audio-less file) while Whisper happens
+    to be absent must still surface as a real 500 — not a misleading installer."""
+    _project(client, 'en')
+    monkeypatch.setattr(T, 'transcribe_file', lambda *a, **k: (_ for _ in ()).throw(
+        RuntimeError('ffmpeg audio extraction failed: no audio stream')))
+    resp = client.post('/project/p/transcribe')
+    body = resp.get_json()
+    assert resp.status_code == 500
+    assert not body.get('needs_whisper_install')
+    assert client._saved.get('status') == 'error'
+
+
+def test_model_cache_rejects_truncated_pt(monkeypatch, tmp_path):
+    """A download interrupted mid-write leaves a truncated large-v3-turbo.pt at
+    the final path. _whisper_model_cached must reject it on size so the install
+    actually completes instead of reporting a false 'ready' on a corrupt model."""
+    d = tmp_path / 'whisper'
+    d.mkdir()
+    monkeypatch.setattr(A, '_whisper_cache_dir', lambda: str(d))
+
+    assert A._whisper_model_cached() is False  # nothing cached yet
+
+    partial = d / 'large-v3-turbo.pt'
+    partial.write_bytes(b'\x00' * 4096)         # truncated partial
+    assert A._whisper_model_cached() is False
+
+    with open(partial, 'wb') as f:              # full-size (sparse) weights
+        f.truncate(A._WHISPER_MODEL_MIN_BYTES + 1)
+    assert A._whisper_model_cached() is True
+
+
+def test_stream_subprocess_heartbeat_when_child_quiet():
+    """The banner must keep moving even when the child emits nothing
+    newline-terminated for a while (the 'stuck on Starting install' report). A
+    heartbeat surfaces an elapsed clock during the quiet stretch."""
+    details = []
+    prog = (
+        'import sys, time\n'
+        'sys.stdout.write("downloading the speech model\\n"); sys.stdout.flush()\n'
+        'time.sleep(0.6)\n'   # go quiet — no newline — long enough for heartbeats
+    )
+    rc, _tail = A._stream_subprocess(
+        [sys.executable, '-c', prog], details.append, heartbeat_interval=0.15)
+    assert rc == 0
+    assert any('elapsed' in d for d in details), \
+        'expected a heartbeat with elapsed time during the quiet stretch'
+
+
 def test_whisper_ready_requires_package_and_model(monkeypatch):
     """_whisper_ready gates on BOTH the package and the cached model so the UI
     doesn't report 'done' while the ~1.5GB model is still missing."""


### PR DESCRIPTION
Reliability fixes for the issues that surfaced right after v3.5.9 — the open GitHub issue **#39** plus the two follow-ups from the Reddit thread (install hang, AI-analysis empty results). Root-caused with a multi-agent investigation + adversarial verification; ships only the load-bearing fixes (a couple of initially-proposed changes were dropped after verification flagged one as a regression and one as targeting an unreachable path).

## 1. #39 — "No transcription engine found" (the open issue)
English jobs try Parakeet first. When Parakeet crashes/fails on a file (the issue #23 Metal-crash class — certain MXF/AVC and some mp4 inputs), it falls back to WhisperX/Whisper, which **isn't bundled** on a fresh DMG. That dead-ended with a bare `pip install …` 500 and no in-app installer — the same dead-end class as #36, but for English.

- `app.py` `/transcribe` except handler now offers the **same on-demand Whisper installer for any language** once every engine is exhausted (gated on the `No transcription engine found` signal **and** `_whisper_ready()`), and keeps the project at `status='uploaded'` so the banner survives a reload.
- The pre-flight guard is deliberately left English-bypassed (English may still succeed via Parakeet).
- Frontend banner copy is now language-agnostic (English users were being told their audio was "non-English").

Once the user installs Whisper once, future Parakeet crashes silently fall back to it — no more dead-end.

## 2. AI Analysis "produced no results" on German / long interviews
Ollama (`format='json'`) truncates output at `num_predict` (`done_reason='length'`); token-verbose languages (German ≈ 40–50% more tokens for the same verbatim quotes) overflow routinely. `_repair_truncated_json` was closing braces at the raw cut point, leaving a dangling key/value → invalid JSON → **the whole reply (including its complete leading items) was discarded** → all categories empty → the misleading "the model may need to be restarted" message (a restart never helped).

- Rewrote `_repair_truncated_json` to rewind to the last fully-formed element of the **deepest still-open container** and close the rest — every complete item survives, only the half-written trailing one is dropped. Idempotent on valid JSON.
- Raised the analysis `num_predict` ceiling **4096 → 8192** so most passes never truncate.
- Replaced the misleading error message with an honest, actionable one.
- Guarded b-roll partials (no timecode → skip).

## 3. Install stuck on "Starting install…"
The installer's progress only updated on a newline boundary, so `pip` piped to a non-TTY and the ~1.6 GB model download could go quiet for minutes inside a blocking read, leaving the banner frozen.

- Background **heartbeat** in `_stream_subprocess` (elapsed clock) that runs independently of the read, so the banner always moves while the worker is alive.
- `elapsed` field on the status poll; frontend shows it and surfaces "lost contact" after repeated poll failures instead of freezing silently.

## 4. Hardening (from the completeness audit)
An interrupted model download leaves a truncated `large-v3-turbo.pt` at the final path, which the filename-only check reported as "ready" (re-introducing the #13/#36 silent-redownload symptom).
- `_whisper_model_cached()` now requires a full-size file (≥1.5 GB floor).
- The worker deletes the undersized partial on failure so "Try again" re-downloads cleanly.

## Tests
- `tests/test_whisper_install_guard.py`: English no-engine → installer; non-engine English errors still 500; model size-floor rejects truncated `.pt`; install heartbeat fires during a quiet child.
- `tests/test_json_repair.py` (new): all canonical truncation shapes parse, complete items survive, nested arrays preserved, valid JSON untouched, end-to-end through `_parse_json_response`.

All new/extended tests pass. The 18 pre-existing failures on `main` (chat-prompt / editorial-DNA suites) are unrelated to this change and reproduce on the base branch.

> Note: the actual 3.5.10 DMG still needs the local signed/notarized build + GitHub release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)